### PR TITLE
#29 pg_restore.exe, pg_dump.exe 実行時のプロセス終了タイムアウトを無制限に変更

### DIFF
--- a/HouseholdAccountBook/Adapters/DbHandler/NpgsqlDbHandler.cs
+++ b/HouseholdAccountBook/Adapters/DbHandler/NpgsqlDbHandler.cs
@@ -95,7 +95,7 @@ namespace HouseholdAccountBook.DbHandler
                 Process process = Process.Start(info);
                 Log.Info("Process executing...");
                 if (waitForFinish) {
-                    if (process.WaitForExit(pgPassConf ? 10 * 1000 : -1)) {
+                    if (process.WaitForExit(-1)) {
                         localExitCode = process.ExitCode;
                         if (localExitCode != 0) {
                             using (StreamReader r = process.StandardError) {
@@ -159,7 +159,7 @@ namespace HouseholdAccountBook.DbHandler
                 Log.Info("Start Restore");
 
                 Process process = Process.Start(info);
-                if (process.WaitForExit(pgPassConf ? 10 * 1000 : -1)) {
+                if (process.WaitForExit(-1)) {
                     localExitCode = process.ExitCode;
                     if (localExitCode != 0) {
                         using (StreamReader r = process.StandardError) {


### PR DESCRIPTION
﻿## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- pg_restore.exe の実行時に、プロセスの実行時間が10秒を超えてしまい、インポートに失敗したと表示されてしまう

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- pg_restore.exe, pg_dump.exe 実行時のプロセス終了タイムアウトを無制限に変更

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. PostgreSQL を利用する設定にする
1. 設定 > DB設定 > 接続情報 > PostgreSQL > パスワード > pgpass.conf を指定する を選択して保存する
1. ファイル > インポート > カスタム形式ファイル  が成功する
1. ファイル > エクスポート > カスタム形式ファイル が成功する

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #29 

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- なし
