### PR TITLE
#133 店舗/備考の選択が機能しない

### DIFF
--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -4,6 +4,13 @@
 
 ## 2026
 
+### 2026-04-12
+
+- ActionRegistrationWindow, ActionListRegistrationWindow, MoveRegistrationWindow
+   - ↑編集時、店舗 / 備考が表示されないのを修正 - refs #133
+   - ↑登録時、店舗 / 備考が保存されないのを修正 - refs #133
+   - △項目変更時、店舗 / 備考の選択が維持されるように変更 - refs #133 
+
 ### 2026-04-11
 
 - 全体

--- a/HouseholdAccountBook/ViewModels/Loaders/SettingViewModelLoader.cs
+++ b/HouseholdAccountBook/ViewModels/Loaders/SettingViewModelLoader.cs
@@ -50,8 +50,8 @@ namespace HouseholdAccountBook.ViewModels.Loaders
             await vm.DebitBookSelectorVM.LoadAsync(bm.DebitBookId);
             vm.TextEncodingSelectorVM.SetLoader(() => EncodingUtil.GetTextEncodingList());
             await vm.TextEncodingSelectorVM.LoadAsync(bm.TextEncoding);
-            vm.RelationSelectorVM.SetLoader(async () => (await this.mService.LoadRelationListAsync(bookId)).Select(model => new RelationViewModel(model)));
-            await vm.RelationSelectorVM.LoadAsync(SelectorMode.FirstOrDefault);
+            vm.RelationSelectorVM.SetLoader(async () => (await this.mService.LoadRelationListAsync(bookId)).Select(model => new RelationViewModel(model)), mode: SelectorMode.FirstOrDefault);
+            await vm.RelationSelectorVM.LoadAsync();
 
             return vm;
         }
@@ -112,12 +112,12 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                     // 項目
                     ItemIdObj itemId = id.Id;
                     vm = new(await this.mService.LoadItemAsync(itemId));
-                    vm.RelationSelectorVM.SetLoader(async () => (await this.mService.LoadRelationListAsync(itemId)).Select(model => new RelationViewModel(model)));
-                    await vm.RelationSelectorVM.LoadAsync(SelectorMode.FirstOrDefault);
-                    vm.ShopSelectorVM.SetLoader(async () => await this.mAppService.LoadShopListAsync(itemId));
-                    await vm.ShopSelectorVM.LoadAsync(SelectorMode.FirstOrDefault);
-                    vm.RemarkSelectorVM.SetLoader(async () => await this.mAppService.LoadRemarkListAsync(itemId));
-                    await vm.RemarkSelectorVM.LoadAsync(SelectorMode.FirstOrDefault);
+                    vm.RelationSelectorVM.SetLoader(async () => (await this.mService.LoadRelationListAsync(itemId)).Select(model => new RelationViewModel(model)), mode: SelectorMode.FirstOrDefault);
+                    await vm.RelationSelectorVM.LoadAsync();
+                    vm.ShopSelectorVM.SetLoader(async () => await this.mAppService.LoadShopListAsync(itemId), mode: SelectorMode.FirstOrDefault);
+                    await vm.ShopSelectorVM.LoadAsync();
+                    vm.RemarkSelectorVM.SetLoader(async () => await this.mAppService.LoadRemarkListAsync(itemId), mode: SelectorMode.FirstOrDefault);
+                    await vm.RemarkSelectorVM.LoadAsync();
                     break;
                 }
             }

--- a/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
@@ -17,7 +17,7 @@ using System.Windows.Controls;
 namespace HouseholdAccountBook.ViewModels
 {
     /// <summary>
-    /// <see cref="SelectorViewModel{VM, KEY}"/> で <see cref="SelectorViewModel{VM, KEY}.SelectorViewModel"/> 時に KEY を選択するモード
+    /// <see cref="SelectorViewModel{VM, KEY}"/> で読み込み時に KEY を選択するモード
     /// </summary>
     public enum SelectorMode
     {
@@ -141,9 +141,7 @@ namespace HouseholdAccountBook.ViewModels
                 KEY? old = this.mSelectedKey;
                 if (this.SetProperty(ref this.mSelectedKey, value)) {
                     // KEYの一致するVMが存在するならSelectedItemに設定する。なければdefaultにしてfieldに入力値を保持する
-                    this.mSelectedItem = this.ItemList.Any(vm => KeyEquals(this.mSelector(vm), value))
-                        ? this.ItemList.First(vm => KeyEquals(this.mSelector(vm), value))
-                        : default;
+                    this.mSelectedItem = this.ItemList.FirstOrDefault(vm => KeyEquals(this.mSelector(vm), value));
 
                     // 読込処理中以外か
                     if (!this.mOnLoad) {
@@ -334,6 +332,8 @@ namespace HouseholdAccountBook.ViewModels
                     case SelectorMode.Force:
                         this.SelectedKey = tmpSelection;
                         break;
+                    default:
+                        throw new NotSupportedException();
                 }
 
                 if (!KeyEquals(this.SelectedKey, oldKey)) {

--- a/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
@@ -10,20 +10,23 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Controls;
 
 #nullable enable
 
 namespace HouseholdAccountBook.ViewModels
 {
     /// <summary>
-    /// <see cref="SelectorViewModel"/> で <see cref="KEY"/> を選択するモード
+    /// <see cref="SelectorViewModel{VM, KEY}"/> で <see cref="SelectorViewModel{VM, KEY}.SelectorViewModel"/> 時に KEY を選択するモード
     /// </summary>
     public enum SelectorMode
     {
         // 一致する項目がなければデフォルト(KEYがクラスなら選択なし状態)を選択する
         FirstOrDefault,
         // 一致する項目がなければ先頭の項目を選択する
-        FirstOrElementAtOrDefault
+        FirstOrElementAtOrDefault,
+        // 一致する項目がなくとも選択する
+        Force
     }
 
     /// <summary>
@@ -64,6 +67,10 @@ namespace HouseholdAccountBook.ViewModels
         /// </summary>
         private Func<FuncLog, CancellationToken, Task<IEnumerable<VM>>>? mLoadAsync;
         /// <summary>
+        /// 読み込み時の選択モード
+        /// </summary>
+        private SelectorMode mMode;
+        /// <summary>
         /// 読込処理中か
         /// </summary>
         private bool mOnLoad = false;
@@ -100,16 +107,18 @@ namespace HouseholdAccountBook.ViewModels
         /// 選択 <see cref="VM"/>
         /// </summary>
         public VM? SelectedItem {
-            get;
+            get => this.mSelectedItem;
             set {
-                KEY? old = this.SelectedKey;
-                if (this.SetProperty(ref field, value)) {
+                KEY? old = this.mSelectedKey;
+                if (this.SetProperty(ref this.mSelectedItem, value)) {
+                    this.mSelectedKey = this.mSelector(value);
+
                     // 読込処理中以外か
                     if (!this.mOnLoad) {
                         // NULLの場合に通知するか
-                        if (this.SelectedKey != null || this.mItemChangedIfNull) {
+                        if (this.mSelectedKey != null || this.mItemChangedIfNull) {
                             // 待機せずデタッチして選択時の処理をする
-                            _ = this.OnSelectionChangedAsync(old, this.SelectedKey);
+                            _ = this.OnSelectionChangedAsync(old, this.mSelectedKey);
                         }
                     }
 
@@ -119,12 +128,41 @@ namespace HouseholdAccountBook.ViewModels
             }
         }
         /// <summary>
+        /// 選択 <see cref="VM"/> 内部値
+        /// </summary>
+        private VM? mSelectedItem = default;
+        /// <summary>
         /// 選択 <see cref="KEY"/>
         /// </summary>
+        /// <remarks>編集可能な <see cref="ComboBox"/> では <see cref="ComboBox.Text"/> とこのプロパティを Bind する</remarks>
         public KEY? SelectedKey {
-            get => this.mSelector.Invoke(this.SelectedItem) ?? default;
-            set => this.SelectedItem = this.ItemList.FirstOrElementAtOrDefault(vm => EqualityComparer<KEY>.Default.Equals(this.mSelector.Invoke(vm), value), 0);
+            get => this.mSelectedKey;
+            set {
+                KEY? old = this.mSelectedKey;
+                if (this.SetProperty(ref this.mSelectedKey, value)) {
+                    // KEYの一致するVMが存在するならSelectedItemに設定する。なければdefaultにしてfieldに入力値を保持する
+                    this.mSelectedItem = this.ItemList.Any(vm => KeyEquals(this.mSelector(vm), value))
+                        ? this.ItemList.First(vm => KeyEquals(this.mSelector(vm), value))
+                        : default;
+
+                    // 読込処理中以外か
+                    if (!this.mOnLoad) {
+                        // NULLの場合に通知するか
+                        if (this.mSelectedKey != null || this.mItemChangedIfNull) {
+                            // 待機せずデタッチして選択時の処理をする
+                            _ = this.OnSelectionChangedAsync(old, this.mSelectedKey);
+                        }
+                    }
+
+                    this.RaisePropertyChanged(nameof(this.SelectedItem));
+                    this.RaisePropertyChanged(nameof(this.SelectedIndex));
+                }
+            }
         }
+        /// <summary>
+        /// 選択 <see cref="KEY"/> 内部値
+        /// </summary>
+        private KEY? mSelectedKey = default;
         /// <summary>
         /// 選択インデックス
         /// </summary>
@@ -169,23 +207,34 @@ namespace HouseholdAccountBook.ViewModels
         }
 
         /// <summary>
-        /// <see cref="VM"> リスト読込処理を設定する
+        /// 2 つのキー値が等しいかどうかを判定する
         /// </summary>
-        /// <param name="load">[同期] <see cref="VM"/> リスト読込処理</param>
-        /// <param name="canLoad">Load可能判定処理</param>
-        public void SetLoader(Func<IEnumerable<VM>> load, Func<bool>? canLoad = null) => this.SetLoader(funcLog => load(), canLoad);
+        /// <remarks>このメソッドは型パラメーター KEY の既定の等値比較子を使用して比較を行う</remarks>
+        /// <param name="key1">比較する最初のキー値</param>
+        /// <param name="key2">比較する 2 番目のキー値</param>
+        /// <returns>キー値が等しい場合は <see langword="true"/>。それ以外の場合は <see langword="false"/></returns>
+        private static bool KeyEquals(KEY? key1, KEY? key2) => EqualityComparer<KEY>.Default.Equals(key1, key2);
+
         /// <summary>
         /// <see cref="VM"> リスト読込処理を設定する
         /// </summary>
         /// <param name="load">[同期] <see cref="VM"/> リスト読込処理</param>
         /// <param name="canLoad">Load可能判定処理</param>
-        public void SetLoader(Func<FuncLog, IEnumerable<VM>> load, Func<bool>? canLoad = null)
+        public void SetLoader(Func<IEnumerable<VM>> load, Func<bool>? canLoad = null, SelectorMode mode = SelectorMode.FirstOrElementAtOrDefault) =>
+            this.SetLoader(funcLog => load(), canLoad, mode);
+        /// <summary>
+        /// <see cref="VM"> リスト読込処理を設定する
+        /// </summary>
+        /// <param name="load">[同期] <see cref="VM"/> リスト読込処理</param>
+        /// <param name="canLoad">Load可能判定処理</param>
+        public void SetLoader(Func<FuncLog, IEnumerable<VM>> load, Func<bool>? canLoad = null, SelectorMode mode = SelectorMode.FirstOrElementAtOrDefault)
         {
             using FuncLog funcLog = new(fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(SetLoader)}");
 
             this.mCanLoad = canLoad;
             this.mLoad = load;
             this.mLoadAsync = null;
+            this.mMode = mode;
         }
 
         /// <summary>
@@ -193,25 +242,28 @@ namespace HouseholdAccountBook.ViewModels
         /// </summary>
         /// <param name="loadAsync">[非同期] <see cref="VM"> リスト読込処理</param>
         /// <param name="canLoad">Load可能判定処理</param>
-        public void SetLoader(Func<Task<IEnumerable<VM>>> loadAsync, Func<bool>? canLoad = null) => this.SetLoader((funcLog, token) => loadAsync(), canLoad);
+        public void SetLoader(Func<Task<IEnumerable<VM>>> loadAsync, Func<bool>? canLoad = null, SelectorMode mode = SelectorMode.FirstOrElementAtOrDefault) =>
+            this.SetLoader((funcLog, token) => loadAsync(), canLoad, mode);
         /// <summary>
         /// <see cref="VM"> リスト読込処理を設定する
         /// </summary>
         /// <param name="loadAsync">[非同期] <see cref="VM"> リスト読込処理</param>
         /// <param name="canLoad">Load可能判定処理</param>
-        public void SetLoader(Func<CancellationToken, Task<IEnumerable<VM>>> loadAsync, Func<bool>? canLoad = null) => this.SetLoader((funcLog, token) => loadAsync(token), canLoad);
+        public void SetLoader(Func<CancellationToken, Task<IEnumerable<VM>>> loadAsync, Func<bool>? canLoad = null, SelectorMode mode = SelectorMode.FirstOrElementAtOrDefault) =>
+            this.SetLoader((funcLog, token) => loadAsync(token), canLoad, mode);
         /// <summary>
         /// <see cref="VM"> リスト読込処理を設定する
         /// </summary>
         /// <param name="loadAsync">[非同期] <see cref="VM"> リスト読込処理</param>
         /// <param name="canLoad">Load可能判定処理</param>
-        public void SetLoader(Func<FuncLog, CancellationToken, Task<IEnumerable<VM>>> loadAsync, Func<bool>? canLoad = null)
+        public void SetLoader(Func<FuncLog, CancellationToken, Task<IEnumerable<VM>>> loadAsync, Func<bool>? canLoad = null, SelectorMode mode = SelectorMode.FirstOrElementAtOrDefault)
         {
             using FuncLog funcLog = new(fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(SetLoader)}");
 
             this.mCanLoad = canLoad;
             this.mLoad = null;
             this.mLoadAsync = loadAsync;
+            this.mMode = mode;
         }
 
         /// <summary>
@@ -221,33 +273,18 @@ namespace HouseholdAccountBook.ViewModels
         private bool CanLoad() => this.mCanLoad?.Invoke() ?? true;
 
         /// <summary>
-        /// [非同期] <see cref="VM"/> リストを読込む
+        /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
         /// </summary>
         /// <param name="token">キャンセル用トークン</param>
         /// <returns></returns>
-        public async Task LoadAsync(CancellationToken token = default) => await this.LoadAsync(default, SelectorMode.FirstOrElementAtOrDefault, token);
+        public async Task LoadAsync(CancellationToken token = default) => await this.LoadAsync(default, token);
         /// <summary>
         /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
         /// </summary>
         /// <param name="selection"><see cref="VM"/> を選択するキー. nullの場合は現在選択中の <see cref="VM"/> を選択する</param>
         /// <param name="token">キャンセル用トークン</param>
         /// <returns></returns>
-        public async Task LoadAsync(KEY? selection, CancellationToken token) => await this.LoadAsync(selection, SelectorMode.FirstOrElementAtOrDefault, token);
-        /// <summary>
-        /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
-        /// </summary>
-        /// <param name="mode"><see cref="VM"> を選択するモード</param>
-        /// <param name="token">キャンセル用トークン</param>
-        /// <returns></returns>
-        public async Task LoadAsync(SelectorMode mode, CancellationToken token = default) => await this.LoadAsync(default, mode, token);
-        /// <summary>
-        /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
-        /// </summary>
-        /// <param name="selection"><see cref="VM"/> を選択するキー. nullの場合は現在選択中の <see cref="VM"/> を選択する</param>
-        /// <param name="mode"><see cref="VM"> を選択するモード</param>
-        /// <param name="token">キャンセル用トークン</param>
-        /// <returns></returns>
-        public async Task LoadAsync(KEY? selection, SelectorMode mode = SelectorMode.FirstOrElementAtOrDefault, CancellationToken token = default)
+        public async Task LoadAsync(KEY? selection, CancellationToken token = default)
         {
             using FuncLog funcLog = new(new { selection }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(LoadAsync)}");
 
@@ -287,13 +324,19 @@ namespace HouseholdAccountBook.ViewModels
                 }
 
                 KEY? tmpSelection = selection ?? oldKey;
-                // ジェネリックで安全に比較するために、 EqualityComparer<T>.Default を用いる
-                this.SelectedItem = mode switch {
-                    SelectorMode.FirstOrElementAtOrDefault => this.ItemList.FirstOrElementAtOrDefault(vm => EqualityComparer<KEY>.Default.Equals(this.mSelector(vm), tmpSelection), 0),
-                    SelectorMode.FirstOrDefault => this.ItemList.FirstOrDefault(vm => EqualityComparer<KEY>.Default.Equals(this.mSelector(vm), tmpSelection)),
-                    _ => throw new NotImplementedException()
-                };
-                if (!EqualityComparer<KEY>.Default.Equals(this.SelectedKey, oldKey)) {
+                switch (this.mMode) {
+                    case SelectorMode.FirstOrElementAtOrDefault:
+                        this.SelectedItem = this.ItemList.FirstOrElementAtOrDefault(vm => KeyEquals(this.mSelector(vm), tmpSelection), 0);
+                        break;
+                    case SelectorMode.FirstOrDefault:
+                        this.SelectedItem = this.ItemList.FirstOrDefault(vm => KeyEquals(this.mSelector(vm), tmpSelection));
+                        break;
+                    case SelectorMode.Force:
+                        this.SelectedKey = tmpSelection;
+                        break;
+                }
+
+                if (!KeyEquals(this.SelectedKey, oldKey)) {
                     // NULLの場合に通知するか
                     if (this.SelectedItem != null || this.mItemChangedIfNull) {
                         // 子の読込処理を待機するためにここで呼ぶ

--- a/HouseholdAccountBook/ViewModels/Windows/ActionListRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/ActionListRegistrationWindowViewModel.cs
@@ -200,10 +200,10 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 () => this.BookSelectorVM.SelectedKey != null && this.CategorySelectorVM.SelectedKey != null);
             this.ShopSelectorVM.SetLoader(
                 async () => await this.mAppService.LoadShopListAsync(this.ItemSelectorVM.SelectedKey, true),
-                () => this.ItemSelectorVM.SelectedKey != null);
+                () => this.ItemSelectorVM.SelectedKey != null, SelectorMode.Force);
             this.RemarkSelectorVM.SetLoader(
                 async () => await this.mAppService.LoadRemarkListAsync(this.ItemSelectorVM.SelectedKey, true),
-                () => this.ItemSelectorVM.SelectedKey != null);
+                () => this.ItemSelectorVM.SelectedKey != null, SelectorMode.Force);
         }
 
         public override void Initialize(WaitCursorManagerFactory waitCursorManagerFactory, DbHandlerFactory dbHandlerFactory)
@@ -346,12 +346,12 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
             DateTime lastActTime = this.InputedDateValueVMList.Max(static tmp => tmp.ActDate);
 
-            if (commonAction.Shop != null && commonAction.Shop != string.Empty) {
+            if (!string.IsNullOrEmpty(commonAction.Shop)) {
                 ShopModel shop = new(commonAction.Shop) { ItemId = commonAction.Item.Id, CurrentActTime = commonAction.ActTime };
                 await this.mService.SaveShopAsync(shop);
             }
 
-            if (commonAction.Remark != null && commonAction.Remark != string.Empty) {
+            if (!string.IsNullOrEmpty(commonAction.Remark)) {
                 RemarkModel remark = new(commonAction.Remark) { ItemId = commonAction.Item.Id, CurrentActTime = commonAction.ActTime };
                 await this.mService.SaveRemarkAsync(remark);
             }

--- a/HouseholdAccountBook/ViewModels/Windows/ActionRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/ActionRegistrationWindowViewModel.cs
@@ -271,10 +271,10 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 () => this.BookSelectorVM.SelectedKey != null && this.CategorySelectorVM.SelectedKey != null);
             this.ShopSelectorVM.SetLoader(
                 async () => await this.mAppService.LoadShopListAsync(this.ItemSelectorVM.SelectedKey, true),
-                () => this.ItemSelectorVM.SelectedKey != null);
+                () => this.ItemSelectorVM.SelectedKey != null, SelectorMode.Force);
             this.RemarkSelectorVM.SetLoader(
                 async () => await this.mAppService.LoadRemarkListAsync(this.ItemSelectorVM.SelectedKey, true),
-                () => this.ItemSelectorVM.SelectedKey != null);
+                () => this.ItemSelectorVM.SelectedKey != null, SelectorMode.Force);
             this.HolidaySettingSelectorVM.SetLoader(() => HolidaySettingKindStr);
         }
 
@@ -400,12 +400,12 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
             ActionIdObj resActionId = await this.mService.SaveActionAsync(action, this.InputedCount, this.SelectedIfLink, this.HolidaySettingSelectorVM.SelectedKey);
 
-            if (action.Shop != null && action.Shop != string.Empty) {
+            if (!string.IsNullOrEmpty(action.Shop)) {
                 ShopModel shop = new(action.Shop) { ItemId = action.Item.Id, CurrentActTime = action.ActTime };
                 await this.mService.SaveShopAsync(shop);
             }
 
-            if (action.Remark != null && action.Remark != string.Empty) {
+            if (!string.IsNullOrEmpty(action.Remark)) {
                 RemarkModel remark = new(action.Remark) { ItemId = action.Item.Id, CurrentActTime = action.ActTime };
                 await this.mService.SaveRemarkAsync(remark);
             }

--- a/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
@@ -251,7 +251,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
             this.CommissionKindSelectorVM.SetLoader(() => CommissionKindStr);
             this.RemarkSelectorVM.SetLoader(
                 async () => await this.mAppService.LoadRemarkListAsync(this.ItemSelectorVM.SelectedKey, true),
-                () => this.ItemSelectorVM.SelectedKey != null);
+                () => this.ItemSelectorVM.SelectedKey != null, SelectorMode.Force);
         }
 
         public override void Initialize(WaitCursorManagerFactory waitCursorManagerFactory, DbHandlerFactory dbHandlerFactory)
@@ -398,7 +398,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
             IEnumerable<ActionIdObj> resActionIdList = await this.mService.SaveMoveActionsAsync(fromAction, toAction, commissionAction);
 
             if (commissionAction.Amount != 0) {
-                if (commissionAction.Remark != null && commissionAction.Remark != string.Empty) {
+                if (!string.IsNullOrEmpty(commissionAction.Remark)) {
                     RemarkModel remark = new(commissionAction.Remark) { ItemId = commissionAction.Item.Id, CurrentActTime = commissionAction.ActTime };
                     await this.mService.SaveRemarkAsync(remark);
                 }

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowListTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowListTabViewModel.cs
@@ -70,7 +70,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                     Tabs.YearlyListTab => await loader.LoadYearlySeriesViewModelListWithinDecadeAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedStartYear, this.Parent.FiscalStartMonth),
                     _ => throw new NotImplementedException(),
                 };
-            });
+            }, mode: SelectorMode.FirstOrDefault);
         }
 
         public override async Task LoadAsync() => await this.LoadAsync(null, null, null);
@@ -89,7 +89,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
 
             using FuncLog funcLog = new(new { balanceKind, categoryId, itemId });
 
-            await this.SeriesSelectorVM.LoadAsync(new Keys(balanceKind, categoryId, itemId), SelectorMode.FirstOrDefault);
+            await this.SeriesSelectorVM.LoadAsync(new Keys(balanceKind, categoryId, itemId));
         }
 
         public override void Initialize(WaitCursorManagerFactory waitCursorManagerFactory, DbHandlerFactory dbHandlerFactory)

--- a/HouseholdAccountBook/Views/Windows/ActionListRegistrationWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/ActionListRegistrationWindow.xaml
@@ -164,13 +164,13 @@
             <TextBlock Grid.Row="7" Grid.Column="0" Margin="5" 
                        Text="{x:Static properties:Resources.TextBlock_ShopName}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
             <ComboBox Grid.Row="7" Grid.Column="1" Margin="5" IsEditable="True"
-                      ItemsSource="{Binding ShopSelectorVM.ItemList}" Text="{Binding ShopSelectorVM.SelectedItem, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name"/>
+                      ItemsSource="{Binding ShopSelectorVM.ItemList}" Text="{Binding ShopSelectorVM.SelectedKey, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name"/>
 
             <!-- 備考 -->
             <TextBlock Grid.Row="8" Grid.Column="0" Margin="5" 
                        Text="{x:Static properties:Resources.TextBlock_Remark}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
             <ComboBox Grid.Row="8" Grid.Column="1" Margin="5" IsEditable="True"
-                      ItemsSource="{Binding RemarkSelectorVM.ItemList}" Text="{Binding RemarkSelectorVM.SelectedItem, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Remark"/>
+                      ItemsSource="{Binding RemarkSelectorVM.ItemList}" Text="{Binding RemarkSelectorVM.SelectedKey, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Remark"/>
 
             <!-- 数値入力ポップアップ -->
             <controls:FollowablePopup x:Name="_popup" IsOpen="{Binding IsEditing, Mode=TwoWay}" AllowsTransparency="True" Placement="Bottom">

--- a/HouseholdAccountBook/Views/Windows/ActionRegistrationWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/ActionRegistrationWindow.xaml
@@ -116,13 +116,13 @@
             <TextBlock Grid.Row="8" Grid.Column="0" Margin="5"
                        Text="{x:Static properties:Resources.TextBlock_ShopName}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
             <ComboBox Grid.Row="8" Grid.Column="1" Margin="5" IsEditable="True" Grid.ColumnSpan="2"
-                      ItemsSource="{Binding ShopSelectorVM.ItemList}" Text="{Binding ShopSelectorVM.SelectedItem, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name"/>
+                      ItemsSource="{Binding ShopSelectorVM.ItemList}" Text="{Binding ShopSelectorVM.SelectedKey, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name"/>
 
             <!-- 備考 -->
             <TextBlock Grid.Row="9" Grid.Column="0" Margin="5"
                        Text="{x:Static properties:Resources.TextBlock_Remark}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
             <ComboBox Grid.Row="9" Grid.Column="1" Margin="5" IsEditable="True" Grid.ColumnSpan="2"
-                      ItemsSource="{Binding RemarkSelectorVM.ItemList}" Text="{Binding RemarkSelectorVM.SelectedItem, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Remark"/>
+                      ItemsSource="{Binding RemarkSelectorVM.ItemList}" Text="{Binding RemarkSelectorVM.SelectedKey, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Remark"/>
 
             <!-- チェック済 -->
             <TextBlock Grid.Row="10" Grid.Column="0" Margin="5" 

--- a/HouseholdAccountBook/Views/Windows/MoveRegistrationWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/MoveRegistrationWindow.xaml
@@ -205,7 +205,7 @@
                     <TextBlock Grid.Row="4" Grid.Column="0" Margin="5" 
                            Text="{x:Static properties:Resources.TextBlock_Remark}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                     <ComboBox Grid.Row="4" Grid.Column="1" Margin="5" Grid.ColumnSpan="2" IsEditable="True"
-                           ItemsSource="{Binding RemarkSelectorVM.ItemList}" Text="{Binding RemarkSelectorVM.SelectedItem, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Remark"/>
+                           ItemsSource="{Binding RemarkSelectorVM.ItemList}" Text="{Binding RemarkSelectorVM.SelectedKey, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Remark"/>
                 </Grid>
             </GroupBox>
         </Grid>


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- 各登録ダイアログを開いた時、店舗 / 備考が選択されない また 選択しても保存されない

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- 編集時、店舗 / 備考が表示されないのを修正
- 登録時、店舗 / 備考が保存されないのを修正
- 項目変更時、店舗 / 備考の選択が維持されるように変更

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 店舗 / 備考が空文字ではない帳簿項目を編集したとき、店舗 / 備考 が登録ダイアログに表示される
1. 帳簿項目登録時、店舗 / 備考 が保存される
1. 登録ダイアログで、項目変更時、店舗 / 備考の選択が維持される

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #133
- refs #108

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
