### PR TITLE
#136 移動登録ダイアログで手数料負担帳簿を変更したときに項目名が選択した帳簿に切り替わらない

### DIFF
--- a/HouseholdAccountBook/App.xaml.cs
+++ b/HouseholdAccountBook/App.xaml.cs
@@ -164,8 +164,6 @@ namespace HouseholdAccountBook
         /// <summary>
         /// 未観測のタスク例外が発生したときに処理を行う
         /// </summary>
-        ///
-        /// <remarks>このメソッドは、未観測のタスク例外が発生した際に例外通知を行い、例外が観測済みであることをマークする</remarks>
         /// <param name="sender">イベントの発生元となるオブジェクト</param>
         /// <param name="e">未観測のタスク例外に関するデータを格納するイベント引数</param>
         private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
@@ -173,17 +171,11 @@ namespace HouseholdAccountBook
             using FuncLog funcLog = new();
 
             if (!e.Observed) {
-                // UIスレッドを取得する
-                Dispatcher dispatcher = Application.Current?.Dispatcher;
-                if (dispatcher is not null) {
-                    // 現在のスレッドをチェックする
-                    if (dispatcher.CheckAccess()) {
-                        NotifyException(e.Exception);
-                    }
-                    else {
-                        // UIスレッドで非同期に実行する
-                        _ = dispatcher.BeginInvoke(NotifyException, e.Exception);
-                    }
+                if (e.Exception is AggregateException exp && exp.InnerException is not null) {
+                    NotifyException(exp.InnerException);
+                }
+                else {
+                    NotifyException(e.Exception);
                 }
             }
             e.SetObserved();
@@ -197,9 +189,9 @@ namespace HouseholdAccountBook
         private void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             using FuncLog funcLog = new();
-            e.Handled = true;
 
             NotifyException(e.Exception);
+            e.Handled = true;
         }
 
         /// <summary>
@@ -208,11 +200,27 @@ namespace HouseholdAccountBook
         ///
         /// <remarks>このメソッドは例外情報をファイルに保存し、そのファイルのパスを通知サービスに渡して通知を行う。例外処理中にさらに例外が発生した場合は、アプリケーションを強制終了する</remarks>
         /// <param name="exp">通知対象となる未処理例外を表す <see cref="Exception"/> オブジェクト</param>
-        private static void NotifyException(Exception exp)
+        /// <param name="onlyLogging">ログ出力のみとするか</param>
+        private static void NotifyException(Exception exp, bool onlyLogging = false)
         {
             using FuncLog funcLog = new();
 
             try {
+                // UIスレッドを取得する
+                Dispatcher dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher is not null) {
+                    // 現在のスレッドがUIスレッドでない場合は、UIスレッドで非同期に実行する
+                    if (!dispatcher.CheckAccess()) {
+                        _ = dispatcher.BeginInvoke(() => NotifyException(exp));
+                        return;
+                    }
+                }
+                else {
+                    // UIスレッドが取得できない場合は、ログ出力だけ行う
+                    NotifyException(exp, true);
+                    return;
+                }
+
                 Log.Error("Unhandled Exception Occurred.");
 
                 Log.Error($"Unhandled Exception Message: {exp.Message}");
@@ -222,9 +230,11 @@ namespace HouseholdAccountBook
                 log.Log(exp);
                 Log.Info($"Create Unhandled Exception Info File: {log.RelatedFilePath}");
 
-                // ハンドルされない例外の発生を通知する
-                string absoluteFilePath = Path.Combine(GetCurrentDir(), log.RelatedFilePath);
-                NotificationService.NotifyUnhandledException(absoluteFilePath);
+                if (!onlyLogging) {
+                    // ハンドルされない例外の発生を通知する
+                    string absoluteFilePath = Path.Combine(GetCurrentDir(), log.RelatedFilePath);
+                    NotificationService.NotifyUnhandledException(absoluteFilePath);
+                }
             }
             catch (Exception ex) {
                 Log.Error($"Exception Occurred in Unhandled Exception Handler: {ex.Message}");

--- a/HouseholdAccountBook/App.xaml.cs
+++ b/HouseholdAccountBook/App.xaml.cs
@@ -173,7 +173,18 @@ namespace HouseholdAccountBook
             using FuncLog funcLog = new();
 
             if (!e.Observed) {
-                NotifyException(e.Exception);
+                // UIスレッドを取得する
+                Dispatcher dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher is not null) {
+                    // 現在のスレッドをチェックする
+                    if (dispatcher.CheckAccess()) {
+                        NotifyException(e.Exception);
+                    }
+                    else {
+                        // UIスレッドで非同期に実行する
+                        _ = dispatcher.BeginInvoke(NotifyException, e.Exception);
+                    }
+                }
             }
             e.SetObserved();
         }
@@ -202,7 +213,7 @@ namespace HouseholdAccountBook
             using FuncLog funcLog = new();
 
             try {
-                Log.Error("Unhandled Exception Occured.");
+                Log.Error("Unhandled Exception Occurred.");
 
                 Log.Error($"Unhandled Exception Message: {exp.Message}");
 
@@ -216,7 +227,7 @@ namespace HouseholdAccountBook
                 NotificationService.NotifyUnhandledException(absoluteFilePath);
             }
             catch (Exception ex) {
-                Log.Error($"Exception Occured in Unhandled Exception Handler: {ex.Message}");
+                Log.Error($"Exception Occurred in Unhandled Exception Handler: {ex.Message}");
                 Current.Shutdown(1); // 例外処理中に例外が発生した場合は強制終了
             }
         }

--- a/HouseholdAccountBook/App.xaml.cs
+++ b/HouseholdAccountBook/App.xaml.cs
@@ -63,6 +63,9 @@ namespace HouseholdAccountBook
             WindowLog.Config = UserSettingService.Instance.WindowLogConfig;
             WindowLocationManager.Config = UserSettingService.Instance.WindowLocationConfig;
 
+            // タスク例外発生時の処理を登録する
+            TaskScheduler.UnobservedTaskException += this.TaskScheduler_UnobservedTaskException;
+
             // shift-jis を使用するために必要
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
@@ -159,6 +162,23 @@ namespace HouseholdAccountBook
         }
 
         /// <summary>
+        /// 未観測のタスク例外が発生したときに処理を行う
+        /// </summary>
+        ///
+        /// <remarks>このメソッドは、未観測のタスク例外が発生した際に例外通知を行い、例外が観測済みであることをマークする</remarks>
+        /// <param name="sender">イベントの発生元となるオブジェクト</param>
+        /// <param name="e">未観測のタスク例外に関するデータを格納するイベント引数</param>
+        private void TaskScheduler_UnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            using FuncLog funcLog = new();
+
+            if (!e.Observed) {
+                NotifyException(e.Exception);
+            }
+            e.SetObserved();
+        }
+
+        /// <summary>
         /// ハンドルされない例外発生時
         /// </summary>
         /// <param name="sender"></param>
@@ -166,16 +186,29 @@ namespace HouseholdAccountBook
         private void App_DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             using FuncLog funcLog = new();
+            e.Handled = true;
+
+            NotifyException(e.Exception);
+        }
+
+        /// <summary>
+        /// 未処理の例外が発生した際に、例外情報をログに記録し、通知サービスを通じて通知する
+        /// </summary>
+        ///
+        /// <remarks>このメソッドは例外情報をファイルに保存し、そのファイルのパスを通知サービスに渡して通知を行う。例外処理中にさらに例外が発生した場合は、アプリケーションを強制終了する</remarks>
+        /// <param name="exp">通知対象となる未処理例外を表す <see cref="Exception"/> オブジェクト</param>
+        private static void NotifyException(Exception exp)
+        {
+            using FuncLog funcLog = new();
 
             try {
                 Log.Error("Unhandled Exception Occured.");
 
-                e.Handled = true;
-                Log.Error($"Unhandled Exception Message: {e.Exception.Message}");
+                Log.Error($"Unhandled Exception Message: {exp.Message}");
 
                 // 例外情報をファイルに保存する
                 ExceptionLog log = new();
-                log.Log(e.Exception);
+                log.Log(exp);
                 Log.Info($"Create Unhandled Exception Info File: {log.RelatedFilePath}");
 
                 // ハンドルされない例外の発生を通知する

--- a/HouseholdAccountBook/Infrastructure/Utilities/Extensions/TaskExtensions.cs
+++ b/HouseholdAccountBook/Infrastructure/Utilities/Extensions/TaskExtensions.cs
@@ -1,0 +1,36 @@
+﻿using HouseholdAccountBook.Infrastructure.Logger;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace HouseholdAccountBook.Infrastructure.Utilities.Extensions
+{
+    /// <summary>
+    /// <see cref="Task"/> の拡張メソッドを提供します
+    /// </summary>
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// <see cref="Task"/> を呼び出し元で待機せずに実行し、完了後に例外をUIスレッドで処理する
+        /// </summary>
+        /// <remarks>
+        /// <see cref="OperationCanceledException"/> は無視し、それ以外の例外は再スローする
+        /// </remarks>
+        /// <param name="task">対象の <see cref="Task"/></param>
+        public static async void FireAndForget(this Task task, [CallerFilePath] string fileName = null, [CallerMemberName] string methodName = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+
+            try {
+                await task;
+            }
+            catch (OperationCanceledException) {
+                Log.Info($"{methodName} Canceled.", fileName, methodName);
+            }
+            catch (Exception) {
+                Log.Error("Exception Occured.", fileName, methodName, lineNumber);
+                throw;
+            }
+        }
+    }
+}

--- a/HouseholdAccountBook/Infrastructure/Utilities/Extensions/TaskExtensions.cs
+++ b/HouseholdAccountBook/Infrastructure/Utilities/Extensions/TaskExtensions.cs
@@ -11,7 +11,7 @@ namespace HouseholdAccountBook.Infrastructure.Utilities.Extensions
     public static class TaskExtensions
     {
         /// <summary>
-        /// <see cref="Task"/> を呼び出し元で待機せずに実行し、完了後に例外をUIスレッドで処理する
+        /// <see cref="Task"/> を呼び出し元で待機せずに実行し、完了後の例外を現在の継続コンテキストで処理する
         /// </summary>
         /// <remarks>
         /// <see cref="OperationCanceledException"/> は無視し、それ以外の例外は再スローする
@@ -28,7 +28,7 @@ namespace HouseholdAccountBook.Infrastructure.Utilities.Extensions
                 Log.Info($"{methodName} Canceled.", fileName, methodName);
             }
             catch (Exception) {
-                Log.Error("Exception Occured.", fileName, methodName, lineNumber);
+                Log.Error("Exception Occurred.", fileName, methodName, lineNumber);
                 throw;
             }
         }

--- a/HouseholdAccountBook/Properties/Resources.en-001.resx
+++ b/HouseholdAccountBook/Properties/Resources.en-001.resx
@@ -1126,4 +1126,13 @@ list</value>
   <data name="Menu_Help_ReleaseNote" xml:space="preserve">
     <value>Release note (_N)...</value>
   </data>
+  <data name="Menu_Debug" xml:space="preserve">
+    <value>Debug (_D)</value>
+  </data>
+  <data name="Menu_Debug_ThrowUnobservedTaskException" xml:space="preserve">
+    <value>Throw unobserved task exception (_O)</value>
+  </data>
+  <data name="Menu_Debug_ThrowUnhandledException" xml:space="preserve">
+    <value>Throw unhandled exception (_H)</value>
+  </data>
 </root>

--- a/HouseholdAccountBook/Properties/Resources.ja.resx
+++ b/HouseholdAccountBook/Properties/Resources.ja.resx
@@ -1126,4 +1126,13 @@
   <data name="Menu_Help_ReleaseNote" xml:space="preserve">
     <value>リリースノート(_N)...</value>
   </data>
+  <data name="Menu_Debug" xml:space="preserve">
+    <value>デバッグ(_D)</value>
+  </data>
+  <data name="Menu_Debug_ThrowUnobservedTaskException" xml:space="preserve">
+    <value>未観測タスク例外スロー(_O)</value>
+  </data>
+  <data name="Menu_Debug_ThrowUnhandledException" xml:space="preserve">
+    <value>未処理例外スロー(_H)</value>
+  </data>
 </root>

--- a/HouseholdAccountBook/Properties/Resources.resx
+++ b/HouseholdAccountBook/Properties/Resources.resx
@@ -1126,4 +1126,13 @@
   <data name="Menu_Help_ReleaseNote" xml:space="preserve">
     <value>リリースノート(_N)...</value>
   </data>
+  <data name="Menu_Debug" xml:space="preserve">
+    <value>デバッグ(_D)</value>
+  </data>
+  <data name="Menu_Debug_ThrowUnobservedTaskException" xml:space="preserve">
+    <value>未観測タスク例外スロー(_O)</value>
+  </data>
+  <data name="Menu_Debug_ThrowUnhandledException" xml:space="preserve">
+    <value>未処理例外スロー(_H)</value>
+  </data>
 </root>

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -8,6 +8,7 @@
 
 - 全体
    - ＋デタッチしたタスクで観測されない例外が発生した場合に通知する機能を追加 - refs #136
+   - △SelectorViewModelでの選択変更処理後に発生した例外を処理するように変更 - refs #136
 
 - MainWindow
    - ↑SelectedTabの変更時にSelectedTabIndexの更新通知が漏れていたため修正 - refs #134

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -6,13 +6,19 @@
 
 ### 2026-04-12
 
+- 全体
+   - ＋デタッチしたタスクで観測されない例外が発生した場合に通知する機能を追加 - refs #136
+
 - MainWindow
-   - ↑SelectedTabの変更時にSelectedTabIndexの更新通知が漏れていたため追加 - refs #134
+   - ↑SelectedTabの変更時にSelectedTabIndexの更新通知が漏れていたため修正 - refs #134
 
 - ActionRegistrationWindow, ActionListRegistrationWindow, MoveRegistrationWindow
    - ↑編集時、店舗 / 備考が表示されないのを修正 - refs #133
    - ↑登録時、店舗 / 備考が保存されないのを修正 - refs #133
    - △項目変更時、店舗 / 備考の選択が維持されるように変更 - refs #133
+
+- MoveRegistrationWindow
+   - ↑手数料の負担帳簿を変更したときに例外が発生するのを修正 - refs #136
 
 ### 2026-04-11
 

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -8,10 +8,11 @@
 
 - 全体
    - ＋デタッチしたタスクで観測されない例外が発生した場合に通知する機能を追加 - refs #136
-   - △SelectorViewModelでの選択変更処理後に発生した例外を処理するように変更 - refs #136
+   - △SelectorViewModelでの選択変更処理後に発生した例外を捕捉するように変更 - refs #136
 
 - MainWindow
    - ↑SelectedTabの変更時にSelectedTabIndexの更新通知が漏れていたため修正 - refs #134
+   - ＋デバッグモード時に、例外を故意に起こすメニューを追加 - refs #136
 
 - ActionRegistrationWindow, ActionListRegistrationWindow, MoveRegistrationWindow
    - ↑編集時、店舗 / 備考が表示されないのを修正 - refs #133
@@ -19,12 +20,12 @@
    - △項目変更時、店舗 / 備考の選択が維持されるように変更 - refs #133
 
 - MoveRegistrationWindow
-   - ↑手数料の負担帳簿を変更したときに例外が発生するのを修正 - refs #136
+   - ↑手数料を負担する帳簿を変更したときに例外が発生するのを修正 - refs #136
 
 ### 2026-04-11
 
 - 全体
-   - UpdateLog.txt を UpdateLog.md に変更 - refs #130
+   - △UpdateLog.txt を UpdateLog.md に変更 - refs #130
    - △設定(Properties.Settings)を直接操作していたのをUserSettingService経由で操作するように変更 - refs #121
    - ↑例外が発生しうる潜在的不具合を修正 - refs #121
    - ＋開発環境の改行コードをCRLFに固定する設定を追加 - refs #121

--- a/HouseholdAccountBook/ViewModels/AsyncRelayCommand.cs
+++ b/HouseholdAccountBook/ViewModels/AsyncRelayCommand.cs
@@ -239,8 +239,8 @@ namespace HouseholdAccountBook.ViewModels
                 catch (OperationCanceledException) {
                     _ = tcs.TrySetCanceled();
                 }
-                catch (Exception ex) {
-                    _ = tcs.TrySetException(ex);
+                catch (Exception exp) {
+                    _ = tcs.TrySetException(exp);
                 }
                 finally {
                     progressWindow?.CloseOnCode();
@@ -272,9 +272,7 @@ namespace HouseholdAccountBook.ViewModels
                 await (this.mMode != ExecutionMode.ProgressWindow ? ExecWrapper(null) : tcs.Task);
             }
             catch (OperationCanceledException) {
-                // ここに至るまでにキャンセルが処理されていないなら例外をrethrowする
-                Log.Debug($"{this.mMemberName} Canceled.", this.mFileName, this.mMemberName);
-                throw;
+                Log.Info($"{this.mMemberName} Canceled.", this.mFileName, this.mMemberName);
             }
             catch (Exception) {
                 Log.Error("Unhandled Exception Occurred.", this.mFileName, this.mMemberName);

--- a/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
@@ -117,8 +117,8 @@ namespace HouseholdAccountBook.ViewModels
                     if (!this.mOnLoad) {
                         // NULLの場合に通知するか
                         if (this.mSelectedKey != null || this.mItemChangedIfNull) {
-                            // 待機せずデタッチして選択時の処理をする
-                            _ = this.OnSelectionChangedAsync(old, this.mSelectedKey);
+                            // 待機せず選択時の処理をする
+                            this.OnSelectionChangedAsync(old, this.mSelectedKey).FireAndForget();
                         }
                     }
 
@@ -147,8 +147,8 @@ namespace HouseholdAccountBook.ViewModels
                     if (!this.mOnLoad) {
                         // NULLの場合に通知するか
                         if (this.mSelectedKey != null || this.mItemChangedIfNull) {
-                            // 待機せずデタッチして選択時の処理をする
-                            _ = this.OnSelectionChangedAsync(old, this.mSelectedKey);
+                            // 待機せず選択時の処理をする
+                            this.OnSelectionChangedAsync(old, this.mSelectedKey).FireAndForget();
                         }
                     }
 

--- a/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
@@ -600,6 +600,21 @@ namespace HouseholdAccountBook.ViewModels.Windows
         public ICommand UpdateCommand => field ??= new AsyncRelayCommand(this.UpdateCommand_ExecuteAsync);
         #endregion
 
+        #region デバッグコマンド
+        /// <summary>
+        /// デバッグコマンド
+        /// </summary>
+        public ICommand DebugCommand => field ?? new RelayCommand(this.DebugCommand_CanExecute);
+        /// <summary>
+        /// 未処理例外スローコマンド
+        /// </summary>
+        public ICommand ThrowUnhandledExceptionCommand => field ?? new RelayCommand(this.ThrowUnhandledExceptionCommand_Execute);
+        /// <summary>
+        /// 未観測タスク例外スローコマンド
+        /// </summary>
+        public ICommand ThrowUnobservedTaskExceptionCommand => field ?? new RelayCommand(this.ThrowUnobservedTaskExceptionCommand_Execute);
+        #endregion
+
         #region ツールコマンド
         /// <summary>
         /// ツールメニューコマンド
@@ -1198,10 +1213,31 @@ namespace HouseholdAccountBook.ViewModels.Windows
         }
         #endregion
 
+        #region デバッグメニュー
+        /// <summary>
+        /// デバッグコマンド実行可能か
+        /// </summary>
+        /// <returns></returns>
+        private bool DebugCommand_CanExecute() => !this.IsChildrenWindowOpened();
+
+        /// <summary>
+        /// 未処理例外スローコマンド処理
+        /// </summary>
+        /// <exception cref="Exception"></exception>
+        private void ThrowUnhandledExceptionCommand_Execute() => throw new Exception("for debug");
+
+        /// <summary>
+        /// 未観測タスク例外スローコマンド処理
+        /// </summary>
+        /// <exception cref="Exception"></exception>
+        private void ThrowUnobservedTaskExceptionCommand_Execute() => new Task(static () => throw new Exception("for debug")).Start();
+        #endregion
+
         #region ツールメニュー
         /// <summary>
         /// ツールコマンド実行可能か
         /// </summary>
+        /// <returns></returns>
         private bool ToolCommand_CanExecute() => !this.IsChildrenWindowOpened();
 
         /// <summary>

--- a/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
@@ -243,7 +243,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     BookIdObj bookId = this.CommissionKindSelectorVM.SelectedKey switch {
                         CommissionKind.MoveFrom => this.FromBookSelectorVM.SelectedKey,
                         CommissionKind.MoveTo => this.ToBookSelectorVM.SelectedKey,
-                        _ => throw new NotSupportedException("SelectedComissionKind"),
+                        _ => throw new NotSupportedException("SelectedCommissionKind"),
                     };
                     return await this.mAppService.LoadItemListAsync(bookId, BalanceKind.Expenses, CategoryIdObj.System);
                 },
@@ -390,13 +390,13 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 Base = new(this.CommissionId, commissionKind switch {
                     CommissionKind.MoveFrom => fromAction.ActTime,
                     CommissionKind.MoveTo => toAction.ActTime,
-                    _ => throw new NotSupportedException("SelectedComissionKind")
+                    _ => throw new NotSupportedException("SelectedCommissionKind")
                 }, -this.InputedCommission ?? 0),
                 GroupId = this.GroupId,
                 Book = new(commissionKind switch {
                     CommissionKind.MoveFrom => fromAction.Book.Id,
                     CommissionKind.MoveTo => toAction.Book.Id,
-                    _ => throw new NotSupportedException("SelectedComissionKind")
+                    _ => throw new NotSupportedException("SelectedCommissionKind")
                 }, string.Empty),
                 Item = new(this.ItemSelectorVM.SelectedKey, string.Empty),
                 Remark = this.RemarkSelectorVM.SelectedKey

--- a/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
@@ -231,24 +231,23 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        /// <exception cref="ArgumentException"></exception>
         public MoveRegistrationWindowViewModel()
         {
             using FuncLog funcLog = new();
 
             this.FromBookSelectorVM.SetLoader(async () => await this.mAppService.LoadBookListAsync());
             this.ToBookSelectorVM.SetLoader(async () => await this.mAppService.LoadBookListAsync());
+            this.CommissionKindSelectorVM.SetLoader(() => CommissionKindStr);
             this.ItemSelectorVM.SetLoader(
                 async () => {
                     BookIdObj bookId = this.CommissionKindSelectorVM.SelectedKey switch {
                         CommissionKind.MoveFrom => this.FromBookSelectorVM.SelectedKey,
                         CommissionKind.MoveTo => this.ToBookSelectorVM.SelectedKey,
-                        _ => throw new ArgumentException("SelectedComissionKind"),
+                        _ => throw new NotSupportedException("SelectedComissionKind"),
                     };
                     return await this.mAppService.LoadItemListAsync(bookId, BalanceKind.Expenses, CategoryIdObj.System);
                 },
                 () => this.FromBookSelectorVM.SelectedKey != null && this.ToBookSelectorVM.SelectedKey != null);
-            this.CommissionKindSelectorVM.SetLoader(() => CommissionKindStr);
             this.RemarkSelectorVM.SetLoader(
                 async () => await this.mAppService.LoadRemarkListAsync(this.ItemSelectorVM.SelectedKey, true),
                 () => this.ItemSelectorVM.SelectedKey != null, SelectorMode.Force);
@@ -263,8 +262,8 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
             this.FromBookSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
             this.ToBookSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
-            this.ItemSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
             this.CommissionKindSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
+            this.ItemSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
             this.RemarkSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
         }
 
@@ -316,8 +315,8 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     }
                     selectingFromBookId = fromAction.Book.Id;
                     selectingToBookId = toAction.Book.Id;
-                    selectingCommissionItemId = commissionAction?.Item.Id;
                     selectingCommissionKind = commissionAction?.Book.Id == toAction.Book.Id ? CommissionKind.MoveTo : CommissionKind.MoveFrom;
+                    selectingCommissionItemId = commissionAction?.Item.Id;
                     selectingCommissionRemark = commissionAction?.Remark;
 
                     this.IsLink = fromAction.ActTime == toAction.ActTime;
@@ -333,8 +332,8 @@ namespace HouseholdAccountBook.ViewModels.Windows
             // リストを更新する
             await this.FromBookSelectorVM.LoadAsync(selectingFromBookId);
             await this.ToBookSelectorVM.LoadAsync(selectingToBookId);
-            await this.ItemSelectorVM.LoadAsync(selectingCommissionItemId);
             await this.CommissionKindSelectorVM.LoadAsync(selectingCommissionKind);
+            await this.ItemSelectorVM.LoadAsync(selectingCommissionItemId);
             await this.RemarkSelectorVM.LoadAsync(selectingCommissionRemark);
 
             switch (this.RegKind) {
@@ -360,7 +359,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
             this.FromBookSelectorVM.Children.Add(this.ItemSelectorVM);
             this.ToBookSelectorVM.SelectionChanged += (sender, e) => this.ToBookChanged?.Invoke(sender, e);
             this.ToBookSelectorVM.Children.Add(this.ItemSelectorVM);
-            this.CommissionKindSelectorVM.SelectionChanged += (sender, e) => this.CommissionKindChanged(sender, e);
+            this.CommissionKindSelectorVM.SelectionChanged += (sender, e) => this.CommissionKindChanged?.Invoke(sender, e);
             this.CommissionKindSelectorVM.Children.Add(this.ItemSelectorVM);
             this.ItemSelectorVM.SelectionChanged += (sender, e) => this.ItemChanged?.Invoke(sender, e);
             this.ItemSelectorVM.Children.Add(this.RemarkSelectorVM);
@@ -388,9 +387,17 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
             CommissionKind commissionKind = this.CommissionKindSelectorVM.SelectedKey;
             ActionModel commissionAction = new() {
-                Base = new(this.CommissionId, commissionKind switch { CommissionKind.MoveFrom => fromAction.ActTime, CommissionKind.MoveTo => toAction.ActTime, _ => DateTime.Now }, -this.InputedCommission ?? 0),
+                Base = new(this.CommissionId, commissionKind switch {
+                    CommissionKind.MoveFrom => fromAction.ActTime,
+                    CommissionKind.MoveTo => toAction.ActTime,
+                    _ => throw new NotSupportedException("SelectedComissionKind")
+                }, -this.InputedCommission ?? 0),
                 GroupId = this.GroupId,
-                Book = new(commissionKind switch { CommissionKind.MoveFrom => fromAction.Book.Id, CommissionKind.MoveTo => toAction.Book.Id, _ => BookIdObj.System }, string.Empty),
+                Book = new(commissionKind switch {
+                    CommissionKind.MoveFrom => fromAction.Book.Id,
+                    CommissionKind.MoveTo => toAction.Book.Id,
+                    _ => throw new NotSupportedException("SelectedComissionKind")
+                }, string.Empty),
                 Item = new(this.ItemSelectorVM.SelectedKey, string.Empty),
                 Remark = this.RemarkSelectorVM.SelectedKey
             };

--- a/HouseholdAccountBook/Views/Windows/MainWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/MainWindow.xaml
@@ -252,6 +252,14 @@
                 <!-- 更新 -->
                 <MenuItem Header="{x:Static properties:Resources.Menu_View_Update}" Command="{Binding UpdateCommand}" InputGestureText="F5"/>
             </MenuItem>
+            <!-- デバッグ -->
+            <MenuItem Header="{x:Static properties:Resources.Menu_Debug}" Command="{Binding DebugCommand}"
+                      Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}">
+                <!-- 未処理例外スロー -->
+                <MenuItem Header="{x:Static properties:Resources.Menu_Debug_ThrowUnhandledException}" Command="{Binding ThrowUnhandledExceptionCommand}"/>
+                <!-- 未観測タスク例外スロー -->
+                <MenuItem Header="{x:Static properties:Resources.Menu_Debug_ThrowUnobservedTaskException}" Command="{Binding ThrowUnobservedTaskExceptionCommand}"/>
+            </MenuItem>
             <!-- ツール -->
             <MenuItem Header="{x:Static properties:Resources.Menu_Tool}" Command="{Binding ToolMenuCommand}">
                 <!-- CSV比較 -->


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- 移動登録ダイアログにおいて、手数料を負担する帳簿(移動元/移動先)を切り替えたときに、項目の一覧が選択した帳簿に切り替わらない

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- デタッチしたタスクで観測されない例外が発生した場合に通知する機能を追加
- デバッグモード時に、例外を故意に起こすメニューを追加
- SelectorViewModelでの選択変更処理後に発生した例外を処理するように変更
- 移動登録ダイアログで手数料の負担帳簿を変更したときに例外が発生するのを修正

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 手数料の項目欄が、選択した手数料を負担する帳簿に応じて切り替わる

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #136
- refs #108

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
