### PR TITLE
#93 設定ダイアログの項目タブと帳簿タブの順序を入れ替える

### DIFF
--- a/HouseholdAccountBook/Models/Enums.cs
+++ b/HouseholdAccountBook/Models/Enums.cs
@@ -233,13 +233,13 @@ namespace HouseholdAccountBook.Models
     public enum SettingsTabs
     {
         /// <summary>
-        /// 項目設定タブ
-        /// </summary>
-        ItemSettingsTab = 0,
-        /// <summary>
         /// 帳簿設定タブ
         /// </summary>
-        BookSettingsTab = 1,
+        BookSettingsTab = 0,
+        /// <summary>
+        /// 項目設定タブ
+        /// </summary>
+        ItemSettingsTab = 1,
         /// <summary>
         /// DB設定タブ
         /// </summary>

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -4,6 +4,11 @@
 
 ## 2026
 
+### 2026-04-17
+
+- SettingsWindow
+   - △帳簿タブと項目タブの順序を変更 - refs #93
+
 ### 2026-04-13
 
 - PeriodSelectionWindow

--- a/HouseholdAccountBook/ViewModels/Windows/SettingsWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/SettingsWindowViewModel.cs
@@ -20,13 +20,13 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public event EventHandler NeedToUpdateChanged {
             add {
-                this.ItemTabVM.NeedToUpdateChanged += value;
                 this.BookTabVM.NeedToUpdateChanged += value;
+                this.ItemTabVM.NeedToUpdateChanged += value;
                 this.OtherTabVM.NeedToUpdateChanged += value;
             }
             remove {
-                this.ItemTabVM.NeedToUpdateChanged -= value;
                 this.BookTabVM.NeedToUpdateChanged -= value;
+                this.ItemTabVM.NeedToUpdateChanged -= value;
                 this.OtherTabVM.NeedToUpdateChanged -= value;
             }
         }
@@ -57,14 +57,14 @@ namespace HouseholdAccountBook.ViewModels.Windows
         }
 
         /// <summary>
-        /// 項目設定タブVM
-        /// </summary>
-        public SettingsWindowItemTabViewModel ItemTabVM { get; } = new();
-
-        /// <summary>
         /// 帳簿設定タブVM
         /// </summary>
         public SettingsWindowBookTabViewModel BookTabVM { get; } = new();
+
+        /// <summary>
+        /// 項目設定タブVM
+        /// </summary>
+        public SettingsWindowItemTabViewModel ItemTabVM { get; } = new();
 
         /// <summary>
         /// DB設定タブVM
@@ -93,8 +93,8 @@ namespace HouseholdAccountBook.ViewModels.Windows
         {
             this.mChildrenVM.AddRange(
                 [
-                    this.ItemTabVM,
                     this.BookTabVM,
+                    this.ItemTabVM,
                     this.DbTabVM,
                     this.OtherTabVM
                 ]
@@ -106,11 +106,11 @@ namespace HouseholdAccountBook.ViewModels.Windows
             using FuncLog funcLog = new();
 
             switch (this.SelectedTab) {
-                case SettingsTabs.ItemSettingsTab:
-                    await this.ItemTabVM.LoadAsync();
-                    break;
                 case SettingsTabs.BookSettingsTab:
                     await this.BookTabVM.LoadAsync();
+                    break;
+                case SettingsTabs.ItemSettingsTab:
+                    await this.ItemTabVM.LoadAsync();
                     break;
                 case SettingsTabs.DbSettingsTab:
                     await this.DbTabVM.LoadAsync();

--- a/HouseholdAccountBook/ViewModels/WindowsParts/SettingsWindowBookTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/SettingsWindowBookTabViewModel.cs
@@ -266,6 +266,8 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
 
             this.mAppService = new(this.mDbHandlerFactory);
             this.mSettingService = new(this.mDbHandlerFactory);
+
+            this.BookSelectorVM.WaitCursorManagerFactory = waitCursorManagerFactory;
         }
 
         public override async Task LoadAsync() => await this.LoadAsync(null);
@@ -284,6 +286,13 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             }
 
             await this.BookSelectorVM.LoadAsync(bookId);
+            // この時点では選択時イベントハンドラは未登録なので明示的に読み込む
+            if (this.BookSelectorVM.SelectedItem != null) {
+                using WaitCursorManager wcm = this.mWaitCursorManagerFactory.Create();
+
+                SettingViewModelLoader loader = new(this.mAppService, this.mSettingService);
+                this.DisplayedBookSettingVM = await loader.LoadBookSettingViewModelAsync(this.BookSelectorVM.SelectedKey);
+            }
         }
 
         public override void AddEventHandlers()

--- a/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml
@@ -45,204 +45,6 @@
                 </Style>
             </TabControl.ItemContainerStyle>
             
-            <!-- 項目設定 -->
-            <TabItem x:Name="_ItemTab" DataContext="{Binding ItemTabVM}">
-                <TabItem.Header>
-                    <TextBlock Text="{x:Static properties:Resources.TabHeader_ItemSettings}" TextAlignment="Center"/>
-                </TabItem.Header>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="0.3*"/>
-                        <ColumnDefinition Width="5"/>
-                        <ColumnDefinition Width="0.6*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <GroupBox Grid.Column="0" Header="{x:Static properties:Resources.GroupHeader_ItemList}">
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                            </Grid.RowDefinitions>
-
-                            <StackPanel Grid.Row="0" Margin="5" Orientation="Horizontal">
-                                <Button Width="80" Content="{x:Static properties:Resources.Button_AddCategory}" Command="{Binding AddCategoryCommand}" ToolTip="Shift+Ctrl++"/>
-                                <Button Width="80" Content="{x:Static properties:Resources.Button_AddItem}" Command="{Binding AddItemCommand}" ToolTip="Ctrl++"/>
-                                <Button Width="50" Content="{x:Static properties:Resources.Button_Delete}" Command="{Binding DeleteItemCommand}" ToolTip="Delete"/>
-                                <Button Width="25" Content="{x:Static properties:Resources.Button_RaiseSortOrder}" Command="{Binding RaiseItemSortOrderCommand}" ToolTip="Ctrl+↑"/>
-                                <Button Width="25" Content="{x:Static properties:Resources.Button_DropSortOrder}" Command="{Binding DropItemSortOrderCommand}" ToolTip="Ctrl+↓"/>
-                            </StackPanel>
-
-                            <TreeView x:Name="hierarchicalTreeView" Grid.Row="1" Margin="5" ItemsSource="{Binding ItemTreeVMList}"
-                                      SelectedItemChanged="TreeView_SelectedItemChanged">
-                                <TreeView.InputBindings>
-                                    <KeyBinding Gesture="Shift+Ctrl+OEMPlus" Command="{Binding DataContext.AddCategoryCommand, ElementName=_ItemTab}"/>
-                                    <KeyBinding Gesture="Shift+Ctrl+Add" Command="{Binding DataContext.AddCategoryCommand, ElementName=_ItemTab}"/>
-                                    <KeyBinding Gesture="Ctrl+OEMPlus" Command="{Binding DataContext.AddItemCommand, ElementName=_ItemTab}"/>
-                                    <KeyBinding Gesture="Ctrl+Add" Command="{Binding DataContext.AddItemCommand, ElementName=_ItemTab}"/>
-                                    <KeyBinding Gesture="Delete" Command="{Binding DataContext.DeleteItemCommand, ElementName=_ItemTab}"/>
-                                    <KeyBinding Gesture="Ctrl+Up" Command="{Binding DataContext.RaiseItemSortOrderCommand, ElementName=_ItemTab}"/>
-                                    <KeyBinding Gesture="Ctrl+Down" Command="{Binding DataContext.DropItemSortOrderCommand, ElementName=_ItemTab}"/>
-                                </TreeView.InputBindings>
-                                <TreeView.ItemContainerStyle>
-                                    <Style TargetType="TreeViewItem">
-                                        <Setter Property="IsExpanded" Value="True"/>
-                                        <Setter Property="IsSelected" Value="{Binding SelectFlag}"/>
-                                    </Style>
-                                </TreeView.ItemContainerStyle>
-                                <i:Interaction.Behaviors>
-                                    <behaviors:BindSelectedItemToTreeViewBehavior SelectedItem="{Binding SelectedItemTreeVM}"/>
-                                </i:Interaction.Behaviors>
-                                <TreeView.ItemTemplate>
-                                    <HierarchicalDataTemplate DataType="viewmodels:HierarchicalViewModel" 
-                                                              ItemsSource="{Binding ChildrenVMList}">
-                                        <TextBlock Text="{Binding Name}"/>
-                                    </HierarchicalDataTemplate>
-                                </TreeView.ItemTemplate>
-                            </TreeView>
-                        </Grid>
-                    </GroupBox>
-
-                    <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch"/>
-
-                    <Grid Grid.Column="2" DataContext="{Binding DisplayedItemSettingVM}">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="0.3*"/>
-                            <RowDefinition Height="0.3*"/>
-                            <RowDefinition Height="0.3*"/>
-                        </Grid.RowDefinitions>
-                        <!-- 項目情報 -->
-                        <GroupBox Grid.Row="0" Header="{x:Static properties:Resources.GroupHeader_ItemInformation}">
-                            <GroupBox.InputBindings>
-                                <KeyBinding Gesture="Ctrl+S" Command="{Binding DataContext.SaveItemInfoCommand, ElementName=_ItemTab}"/>
-                            </GroupBox.InputBindings>
-                            <Grid>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="0.5*"/>
-                                    <ColumnDefinition Width="0.5*"/>
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
-                                           Text="Id"/>
-                                <TextBlock Grid.Row="0" Grid.Column="1" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
-                                           Text="{Binding Id, TargetNullValue='--'}"/>
-                                <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
-                                           Text="{x:Static properties:Resources.TextBlock_SortOrder}"/>
-                                <TextBlock Grid.Row="1" Grid.Column="1" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
-                                           Text="{Binding SortOrder}"/>
-                                <TextBlock Grid.Row="2" Grid.Column="0" Margin="5"
-                                           Text="{x:Static properties:Resources.TextBlock_ItemName}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Item">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <TextBlock Grid.Row="2" Grid.Column="0" Margin="5"
-                                           Text="{x:Static properties:Resources.TextBlock_CategoryName}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Category">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                                <TextBox Grid.Row="2" Grid.Column="1" Margin="5" 
-                                                    Text="{Binding InputedName, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsRenamable, Converter={StaticResource NegationConverter}}"/>
-                                <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="5" Content="{x:Static properties:Resources.Button_Save}" 
-                                        Command="{Binding DataContext.SaveItemInfoCommand, ElementName=_ItemTab}" ToolTip="Ctrl+S"/>
-                            </Grid>
-                        </GroupBox>
-                        
-                        <!-- 関連付け -->
-                        <GroupBox Grid.Row="1" Header="{x:Static properties:Resources.GroupHeader_Linkage}">
-                            <ListBox Margin="5" ItemsSource="{Binding RelationSelectorVM.ItemList}" SelectedItem="{Binding RelationSelectorVM.SelectedItem}" IsEnabled="{Binding IsSettable}">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                            </Grid.ColumnDefinitions>
-                                            
-                                            <CheckBox Grid.Column="0" IsChecked="{Binding IsRelated}"
-                                                      Command="{Binding DataContext.ChangeItemRelationCommand, ElementName=_ItemTab}"
-                                                      CommandParameter="{Binding DataContext, RelativeSource={RelativeSource Self}}"/>
-                                            <TextBlock Grid.Column="1" Text="{Binding Name}"/>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
-                        </GroupBox>
-                        
-                        <!-- 店舗情報 -->
-                        <GroupBox Grid.Row="2" Header="{x:Static properties:Resources.GroupHeader_Shop}">
-                            <DataGrid Margin="5" x:Name="shopDataGrid" 
-                                      ItemsSource="{Binding ShopSelectorVM.ItemList}" SelectedItem="{Binding ShopSelectorVM.SelectedItem}" IsEnabled="{Binding IsSettable}"
-                                      IsReadOnly="True" SelectionUnit="FullRow" SelectionMode="Single"
-                                      CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False"
-                                      AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="True"
-                                      HorizontalGridLinesBrush="#FFC0C0C0" VerticalGridLinesBrush="#FFC0C0C0" AlternatingRowBackground="#FFFFFFE0" FontSize="10.5" FontFamily="Meiryo">
-
-                                <DataGrid.ColumnHeaderStyle>
-                                    <Style TargetType="DataGridColumnHeader">
-                                        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-                                    </Style>
-                                </DataGrid.ColumnHeaderStyle>
-                                <DataGrid.InputBindings>
-                                    <KeyBinding Gesture="Delete" Command="{Binding DataContext.DeleteShopNameCommand, ElementName=_ItemTab}"/>
-                                </DataGrid.InputBindings>
-                                <DataGrid.Columns>
-                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_ShopName}" Width="*" Binding="{Binding Name}"/>
-                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_UsageCount}" Width="*" Binding="{Binding UsedCount}"/>
-                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_LastUsageDate}" Width="*" Binding="{Binding CurrentActTime, StringFormat='yyyy-MM-dd', TargetNullValue='-'}"/>
-                                </DataGrid.Columns>
-                            </DataGrid>
-                        </GroupBox>
-                        
-                        <!-- 備考情報 -->
-                        <GroupBox Grid.Row="3" Header="{x:Static properties:Resources.GroupHeader_Remark}">
-                            <DataGrid Margin="5" x:Name="remarkDataGrid" 
-                                      ItemsSource="{Binding RemarkSelectorVM.ItemList}" SelectedItem="{Binding RemarkSelectorVM.SelectedItem}" IsEnabled="{Binding IsSettable}"
-                                      IsReadOnly="True" SelectionUnit="FullRow" SelectionMode="Single"
-                                      CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False"
-                                      AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="True"
-                                      HorizontalGridLinesBrush="#FFC0C0C0" VerticalGridLinesBrush="#FFC0C0C0" AlternatingRowBackground="#FFFFFFE0" FontSize="10.5" FontFamily="Meiryo">
-
-                                <DataGrid.ColumnHeaderStyle>
-                                    <Style TargetType="DataGridColumnHeader">
-                                        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-                                    </Style>
-                                </DataGrid.ColumnHeaderStyle>
-                                <DataGrid.InputBindings>
-                                    <KeyBinding Gesture="Delete" Command="{Binding DataContext.DeleteRemarkCommand, ElementName=_ItemTab}"/>
-                                </DataGrid.InputBindings>
-                                <DataGrid.Columns>
-                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_Remark}" Width="*" Binding="{Binding Remark}"/>
-                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_UsageCount}" Width="*" Binding="{Binding UsedCount}"/>
-                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_LastUsageDate}" Width="*" Binding="{Binding CurrentActTime, StringFormat='yyyy-MM-dd', TargetNullValue='-'}"/>
-                                </DataGrid.Columns>
-                            </DataGrid>
-                        </GroupBox>
-                    </Grid>
-                </Grid>
-            </TabItem>
-            
             <!-- 帳簿設定 -->
             <TabItem x:Name="_BookTab" DataContext="{Binding BookTabVM}">
                 <TabItem.Header>
@@ -508,6 +310,204 @@
                 </Grid>
             </TabItem>
 
+            <!-- 項目設定 -->
+            <TabItem x:Name="_ItemTab" DataContext="{Binding ItemTabVM}">
+                <TabItem.Header>
+                    <TextBlock Text="{x:Static properties:Resources.TabHeader_ItemSettings}" TextAlignment="Center"/>
+                </TabItem.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="0.3*"/>
+                        <ColumnDefinition Width="5"/>
+                        <ColumnDefinition Width="0.6*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <GroupBox Grid.Column="0" Header="{x:Static properties:Resources.GroupHeader_ItemList}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+
+                            <StackPanel Grid.Row="0" Margin="5" Orientation="Horizontal">
+                                <Button Width="80" Content="{x:Static properties:Resources.Button_AddCategory}" Command="{Binding AddCategoryCommand}" ToolTip="Shift+Ctrl++"/>
+                                <Button Width="80" Content="{x:Static properties:Resources.Button_AddItem}" Command="{Binding AddItemCommand}" ToolTip="Ctrl++"/>
+                                <Button Width="50" Content="{x:Static properties:Resources.Button_Delete}" Command="{Binding DeleteItemCommand}" ToolTip="Delete"/>
+                                <Button Width="25" Content="{x:Static properties:Resources.Button_RaiseSortOrder}" Command="{Binding RaiseItemSortOrderCommand}" ToolTip="Ctrl+↑"/>
+                                <Button Width="25" Content="{x:Static properties:Resources.Button_DropSortOrder}" Command="{Binding DropItemSortOrderCommand}" ToolTip="Ctrl+↓"/>
+                            </StackPanel>
+
+                            <TreeView x:Name="hierarchicalTreeView" Grid.Row="1" Margin="5" ItemsSource="{Binding ItemTreeVMList}"
+                                      SelectedItemChanged="TreeView_SelectedItemChanged">
+                                <TreeView.InputBindings>
+                                    <KeyBinding Gesture="Shift+Ctrl+OEMPlus" Command="{Binding DataContext.AddCategoryCommand, ElementName=_ItemTab}"/>
+                                    <KeyBinding Gesture="Shift+Ctrl+Add" Command="{Binding DataContext.AddCategoryCommand, ElementName=_ItemTab}"/>
+                                    <KeyBinding Gesture="Ctrl+OEMPlus" Command="{Binding DataContext.AddItemCommand, ElementName=_ItemTab}"/>
+                                    <KeyBinding Gesture="Ctrl+Add" Command="{Binding DataContext.AddItemCommand, ElementName=_ItemTab}"/>
+                                    <KeyBinding Gesture="Delete" Command="{Binding DataContext.DeleteItemCommand, ElementName=_ItemTab}"/>
+                                    <KeyBinding Gesture="Ctrl+Up" Command="{Binding DataContext.RaiseItemSortOrderCommand, ElementName=_ItemTab}"/>
+                                    <KeyBinding Gesture="Ctrl+Down" Command="{Binding DataContext.DropItemSortOrderCommand, ElementName=_ItemTab}"/>
+                                </TreeView.InputBindings>
+                                <TreeView.ItemContainerStyle>
+                                    <Style TargetType="TreeViewItem">
+                                        <Setter Property="IsExpanded" Value="True"/>
+                                        <Setter Property="IsSelected" Value="{Binding SelectFlag}"/>
+                                    </Style>
+                                </TreeView.ItemContainerStyle>
+                                <i:Interaction.Behaviors>
+                                    <behaviors:BindSelectedItemToTreeViewBehavior SelectedItem="{Binding SelectedItemTreeVM}"/>
+                                </i:Interaction.Behaviors>
+                                <TreeView.ItemTemplate>
+                                    <HierarchicalDataTemplate DataType="viewmodels:HierarchicalViewModel" 
+                                                              ItemsSource="{Binding ChildrenVMList}">
+                                        <TextBlock Text="{Binding Name}"/>
+                                    </HierarchicalDataTemplate>
+                                </TreeView.ItemTemplate>
+                            </TreeView>
+                        </Grid>
+                    </GroupBox>
+
+                    <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch"/>
+
+                    <Grid Grid.Column="2" DataContext="{Binding DisplayedItemSettingVM}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="0.3*"/>
+                            <RowDefinition Height="0.3*"/>
+                            <RowDefinition Height="0.3*"/>
+                        </Grid.RowDefinitions>
+                        <!-- 項目情報 -->
+                        <GroupBox Grid.Row="0" Header="{x:Static properties:Resources.GroupHeader_ItemInformation}">
+                            <GroupBox.InputBindings>
+                                <KeyBinding Gesture="Ctrl+S" Command="{Binding DataContext.SaveItemInfoCommand, ElementName=_ItemTab}"/>
+                            </GroupBox.InputBindings>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="0.5*"/>
+                                    <ColumnDefinition Width="0.5*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.Column="0" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
+                                           Text="Id"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
+                                           Text="{Binding Id, TargetNullValue='--'}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="0" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
+                                           Text="{x:Static properties:Resources.TextBlock_SortOrder}"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1" Margin="5" Visibility="{Binding App_IsDebug, Source={StaticResource Settings}, Converter={StaticResource BoolVisibilityConverter}}"
+                                           Text="{Binding SortOrder}"/>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Margin="5"
+                                           Text="{x:Static properties:Resources.TextBlock_ItemName}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Kind}" Value="Item">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBlock Grid.Row="2" Grid.Column="0" Margin="5"
+                                           Text="{x:Static properties:Resources.TextBlock_CategoryName}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Kind}" Value="Category">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                                <TextBox Grid.Row="2" Grid.Column="1" Margin="5" 
+                                                    Text="{Binding InputedName, UpdateSourceTrigger=PropertyChanged}" IsReadOnly="{Binding IsRenamable, Converter={StaticResource NegationConverter}}"/>
+                                <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Margin="5" Content="{x:Static properties:Resources.Button_Save}" 
+                                        Command="{Binding DataContext.SaveItemInfoCommand, ElementName=_ItemTab}" ToolTip="Ctrl+S"/>
+                            </Grid>
+                        </GroupBox>
+                        
+                        <!-- 関連付け -->
+                        <GroupBox Grid.Row="1" Header="{x:Static properties:Resources.GroupHeader_Linkage}">
+                            <ListBox Margin="5" ItemsSource="{Binding RelationSelectorVM.ItemList}" SelectedItem="{Binding RelationSelectorVM.SelectedItem}" IsEnabled="{Binding IsSettable}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+                                            
+                                            <CheckBox Grid.Column="0" IsChecked="{Binding IsRelated}"
+                                                      Command="{Binding DataContext.ChangeItemRelationCommand, ElementName=_ItemTab}"
+                                                      CommandParameter="{Binding DataContext, RelativeSource={RelativeSource Self}}"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding Name}"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </GroupBox>
+                        
+                        <!-- 店舗情報 -->
+                        <GroupBox Grid.Row="2" Header="{x:Static properties:Resources.GroupHeader_Shop}">
+                            <DataGrid Margin="5" x:Name="shopDataGrid" 
+                                      ItemsSource="{Binding ShopSelectorVM.ItemList}" SelectedItem="{Binding ShopSelectorVM.SelectedItem}" IsEnabled="{Binding IsSettable}"
+                                      IsReadOnly="True" SelectionUnit="FullRow" SelectionMode="Single"
+                                      CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False"
+                                      AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="True"
+                                      HorizontalGridLinesBrush="#FFC0C0C0" VerticalGridLinesBrush="#FFC0C0C0" AlternatingRowBackground="#FFFFFFE0" FontSize="10.5" FontFamily="Meiryo">
+
+                                <DataGrid.ColumnHeaderStyle>
+                                    <Style TargetType="DataGridColumnHeader">
+                                        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                    </Style>
+                                </DataGrid.ColumnHeaderStyle>
+                                <DataGrid.InputBindings>
+                                    <KeyBinding Gesture="Delete" Command="{Binding DataContext.DeleteShopNameCommand, ElementName=_ItemTab}"/>
+                                </DataGrid.InputBindings>
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_ShopName}" Width="*" Binding="{Binding Name}"/>
+                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_UsageCount}" Width="*" Binding="{Binding UsedCount}"/>
+                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_LastUsageDate}" Width="*" Binding="{Binding CurrentActTime, StringFormat='yyyy-MM-dd', TargetNullValue='-'}"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </GroupBox>
+                        
+                        <!-- 備考情報 -->
+                        <GroupBox Grid.Row="3" Header="{x:Static properties:Resources.GroupHeader_Remark}">
+                            <DataGrid Margin="5" x:Name="remarkDataGrid" 
+                                      ItemsSource="{Binding RemarkSelectorVM.ItemList}" SelectedItem="{Binding RemarkSelectorVM.SelectedItem}" IsEnabled="{Binding IsSettable}"
+                                      IsReadOnly="True" SelectionUnit="FullRow" SelectionMode="Single"
+                                      CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False"
+                                      AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserSortColumns="True"
+                                      HorizontalGridLinesBrush="#FFC0C0C0" VerticalGridLinesBrush="#FFC0C0C0" AlternatingRowBackground="#FFFFFFE0" FontSize="10.5" FontFamily="Meiryo">
+
+                                <DataGrid.ColumnHeaderStyle>
+                                    <Style TargetType="DataGridColumnHeader">
+                                        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                                    </Style>
+                                </DataGrid.ColumnHeaderStyle>
+                                <DataGrid.InputBindings>
+                                    <KeyBinding Gesture="Delete" Command="{Binding DataContext.DeleteRemarkCommand, ElementName=_ItemTab}"/>
+                                </DataGrid.InputBindings>
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_Remark}" Width="*" Binding="{Binding Remark}"/>
+                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_UsageCount}" Width="*" Binding="{Binding UsedCount}"/>
+                                    <DataGridTextColumn Header="{x:Static properties:Resources.ColumnHeader_LastUsageDate}" Width="*" Binding="{Binding CurrentActTime, StringFormat='yyyy-MM-dd', TargetNullValue='-'}"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </GroupBox>
+                    </Grid>
+                </Grid>
+            </TabItem>
+            
             <!-- DB設定 -->
             <TabItem x:Name="_DbTab" DataContext="{Binding DbTabVM}">
                 <TabItem.Header>

--- a/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml.cs
+++ b/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml.cs
@@ -77,22 +77,21 @@ namespace HouseholdAccountBook.Views.Windows
             if (e.OriginalSource != sender) { return; }
 
             using FuncLog funcLog = new(); // ここで e.OldItems, e.NewItems をログに出すと、StackOverflow になる
+            using WaitCursorManager wcm = new WaitCursorManagerFactory(this).Create();
 
-            using (WaitCursorManager wcm = new WaitCursorManagerFactory(this).Create()) {
-                switch (this.WVM.SelectedTab) {
-                    case SettingsTabs.ItemSettingsTab:
-                        await this.WVM.ItemTabVM.LoadAsync(this.WVM.ItemTabVM.SelectedItemTreeVM?.Kind, this.WVM.ItemTabVM.SelectedItemTreeVM?.Id);
-                        break;
-                    case SettingsTabs.BookSettingsTab:
-                        await this.WVM.BookTabVM.LoadAsync(this.WVM.BookTabVM.BookSelectorVM?.SelectedKey);
-                        break;
-                    case SettingsTabs.DbSettingsTab:
-                        await this.WVM.DbTabVM.LoadAsync();
-                        break;
-                    case SettingsTabs.OtherSettingsTab:
-                        await this.WVM.OtherTabVM.LoadAsync();
-                        break;
-                }
+            switch (this.WVM.SelectedTab) {
+                case SettingsTabs.BookSettingsTab:
+                    await this.WVM.BookTabVM.LoadAsync(this.WVM.BookTabVM.BookSelectorVM?.SelectedKey);
+                    break;
+                case SettingsTabs.ItemSettingsTab:
+                    await this.WVM.ItemTabVM.LoadAsync(this.WVM.ItemTabVM.SelectedItemTreeVM?.Kind, this.WVM.ItemTabVM.SelectedItemTreeVM?.Id);
+                    break;
+                case SettingsTabs.DbSettingsTab:
+                    await this.WVM.DbTabVM.LoadAsync();
+                    break;
+                case SettingsTabs.OtherSettingsTab:
+                    await this.WVM.OtherTabVM.LoadAsync();
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- 設定ダイアログでは、1番目に項目タブ、2番目に帳簿タブが表示されているが、家計簿は帳簿ありき

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- 帳簿タブと項目タブの順序を変更

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 設定を開く

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #93

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
