### PR TITLE
#151 SelectorViewModel を帳簿項目VMに適用する

### DIFF
--- a/HouseholdAccountBook/Infrastructure/Utilities/Extensions/ObjectExtensions.cs
+++ b/HouseholdAccountBook/Infrastructure/Utilities/Extensions/ObjectExtensions.cs
@@ -36,6 +36,8 @@ namespace HouseholdAccountBook.Infrastructure.Utilities.Extensions
             switch (obj) {
                 case string s:
                     return $"\"{s.Replace(Environment.NewLine, "\\r\\n")}\"";
+                case decimal decim:
+                    return $"{decim}";
                 case DateOnly d:
                     return $"{d:yyyy-MM-dd}";
                 case TimeOnly t:

--- a/HouseholdAccountBook/Models/AppServices/CsvCompService.cs
+++ b/HouseholdAccountBook/Models/AppServices/CsvCompService.cs
@@ -80,6 +80,7 @@ namespace HouseholdAccountBook.Models.AppServices
                     IsMatch = dto.IsMatch == 1
                 })];
 
+            funcLog.Returns = actionList.Select(static m => m.ActionId);
             return actionList;
         }
     }

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -4,10 +4,15 @@
 
 ## 2026
 
+### 2026-04-30
+
+- CsvComparisonWindow
+   - △SelectedListをSelectorViewModelに含めるように変更した - refs #151
+
 ### 2026-04-29
 
 - MainWindow
-   - △概要一覧に、SelectorViewModel を適用するように変更した - refs #150
+   - △概要一覧に、SelectorViewModelを適用するように変更した - refs #150
    - ↑月別一覧/年別一覧タブ以外のタブで選択した収支種別/分類/項目が、月別一覧/年別一覧タブの選択に引き継がれないのを修正した - refs #150
    - ↑月別一覧/年別一覧タブで選択した収支種別/分類/項目が、タブを切り替えて戻ってくると維持されないのを修正した - refs #150
    - ↑ログ出力対象の変数がValueTupleのときに値が出力されないのを修正した - refs #150
@@ -21,7 +26,7 @@
 ### 2026-04-28
 
 - MainWindow
-   - ↑CopyCommand で NullReferenceException が発生するのを修正した - refs #148 
+   - ↑CopyCommandでNullReferenceExceptionが発生するのを修正した - refs #148 
 
 ### 2026-04-23
 

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -9,8 +9,11 @@
 - 全体
    - ↑ログ出力対象の変数がdecimalのときに値が出力されないのを修正した - refs #151
 
+- MainWindow
+   - △帳簿項目一覧に、SelectorViewModelを適用するように変更した - refs #151
+
 - CsvComparisonWindow
-   - △SelectedListをSelectorViewModelに含めるように変更した - refs #151
+   - △SelectedItemListをSelectorViewModelに含めるように変更した - refs #151
 
 ### 2026-04-29
 

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -6,6 +6,9 @@
 
 ### 2026-04-30
 
+- 全体
+   - ↑ログ出力対象の変数がdecimalのときに値が出力されないのを修正した - refs #151
+
 - CsvComparisonWindow
    - △SelectedListをSelectorViewModelに含めるように変更した - refs #151
 

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -4,13 +4,14 @@
 
 ## 2026
 
-### 2026-04-30
+### 2026-05-02
 
 - 全体
    - ↑ログ出力対象の変数がdecimalのときに値が出力されないのを修正した - refs #151
 
 - MainWindow
    - △帳簿項目一覧に、SelectorViewModelを適用するように変更した - refs #151
+   - △表示対象の帳簿項目一覧のフィルタ方法を変更した - refs #151 
 
 - CsvComparisonWindow
    - △SelectedItemListをSelectorViewModelに含めるように変更した - refs #151

--- a/HouseholdAccountBook/ViewModels/Component/ActionViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Component/ActionViewModel.cs
@@ -1,4 +1,5 @@
-﻿using HouseholdAccountBook.Models.UiDto;
+﻿using HouseholdAccountBook.Models;
+using HouseholdAccountBook.Models.UiDto;
 using HouseholdAccountBook.Models.ValueObjects;
 using HouseholdAccountBook.ViewModels.Abstract;
 using System;
@@ -38,6 +39,10 @@ namespace HouseholdAccountBook.ViewModels.Component
         public decimal Amount => this.ActionWithBalance.Action.Amount;
 
         /// <summary>
+        /// 収支種別
+        /// </summary>
+        public BalanceKind BalanceKind => this.ActionWithBalance.Action.Category.BalanceKind;
+        /// <summary>
         /// 収入
         /// </summary>
         public decimal? Income => this.ActionWithBalance.Action.Income;
@@ -51,13 +56,25 @@ namespace HouseholdAccountBook.ViewModels.Component
         public decimal? Balance => this.ActionWithBalance.Balance;
 
         /// <summary>
+        /// 帳簿ID
+        /// </summary>
+        public BookIdObj BookId => this.ActionWithBalance.Action.Book.Id;
+        /// <summary>
         /// 帳簿名
         /// </summary>
         public string BookName => this.ActionWithBalance.Action.Book.Name;
         /// <summary>
+        /// 分類ID
+        /// </summary>
+        public CategoryIdObj CategoryId => this.ActionWithBalance.Action.Category.Id;
+        /// <summary>
         /// 分類名
         /// </summary>
         public string CategoryName => this.ActionWithBalance.Action.Category.Name;
+        /// <summary>
+        /// 項目ID
+        /// </summary>
+        public ItemIdObj ItemId => this.ActionWithBalance.Action.Item.Id;
         /// <summary>
         /// 項目名
         /// </summary>

--- a/HouseholdAccountBook/ViewModels/Loaders/SeriesViewModelLoader.cs
+++ b/HouseholdAccountBook/ViewModels/Loaders/SeriesViewModelLoader.cs
@@ -6,7 +6,6 @@ using HouseholdAccountBook.Models.ValueObjects;
 using HouseholdAccountBook.ViewModels.Component;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
 namespace HouseholdAccountBook.ViewModels.Loaders
@@ -28,7 +27,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
         /// <param name="bookId">帳簿ID</param>
         /// <param name="includedTime">月内の時間</param>
         /// <returns>月内日別系列VMリスト</returns>
-        public async Task<ObservableCollection<SeriesViewModel>> LoadDailySeriesViewModelListWithinMonthAsync(BookIdObj bookId, DateOnly includedTime)
+        public async Task<IEnumerable<SeriesViewModel>> LoadDailySeriesViewModelListWithinMonthAsync(BookIdObj bookId, DateOnly includedTime)
         {
             using FuncLog funcLog = new(new { bookId, includedTime });
 
@@ -45,7 +44,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
         /// <param name="startTime">開始時刻</param>
         /// <param name="endTime">終了時刻</param>
         /// <returns>日別系列VMリスト</returns>
-        public async Task<ObservableCollection<SeriesViewModel>> LoadDailySeriesViewModelListAsync(BookIdObj bookId, PeriodObj<DateOnly> period)
+        public async Task<IEnumerable<SeriesViewModel>> LoadDailySeriesViewModelListAsync(BookIdObj bookId, PeriodObj<DateOnly> period)
         {
             using FuncLog funcLog = new(new { bookId, period });
 
@@ -53,8 +52,8 @@ namespace HouseholdAccountBook.ViewModels.Loaders
             decimal balance = await this.mAppService.LoadEndingBalance(bookId, period.Start);
 
             // 系列データ
-            ObservableCollection<SeriesViewModel> vmList = [
-                new SeriesViewModel() {
+            IList<SeriesViewModel> vmList = [
+                new() {
                     OtherName = Properties.Resources.ListName_Balance,
                     Values = [],
                     Periods = []
@@ -138,7 +137,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
         /// <param name="includedTime">年度内の日付</param>
         /// <param name="startMonth">年度開始月</param>
         /// <returns>年度内月別系列VMリスト</returns>
-        public async Task<ObservableCollection<SeriesViewModel>> LoadMonthlySeriesViewModelListWithinYearAsync(BookIdObj bookId, DateOnly includedTime, int startMonth)
+        public async Task<IEnumerable<SeriesViewModel>> LoadMonthlySeriesViewModelListWithinYearAsync(BookIdObj bookId, DateOnly includedTime, int startMonth)
         {
             using FuncLog funcLog = new(new { bookId, includedTime, startMonth });
 
@@ -152,8 +151,8 @@ namespace HouseholdAccountBook.ViewModels.Loaders
             // 開始日までの収支を取得する
             decimal balance = await this.mAppService.LoadEndingBalance(bookId, period.Start);
 
-            ObservableCollection<SeriesViewModel> vmList = [
-                new SeriesViewModel() {
+            IList<SeriesViewModel> vmList = [
+                new() {
                     OtherName = Properties.Resources.ListName_Balance,
                     Values = [],
                     Periods = []
@@ -234,7 +233,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
         /// </summary>
         /// <param name="bookId">帳簿ID</param>
         /// <returns>年別系列VMリスト</returns>
-        public async Task<ObservableCollection<SeriesViewModel>> LoadYearlySeriesViewModelListWithinDecadeAsync(BookIdObj bookId, DateOnly startYear, int startMonth)
+        public async Task<IEnumerable<SeriesViewModel>> LoadYearlySeriesViewModelListWithinDecadeAsync(BookIdObj bookId, DateOnly startYear, int startMonth)
         {
             using FuncLog funcLog = new(new { bookId, startYear, startMonth });
 
@@ -243,8 +242,8 @@ namespace HouseholdAccountBook.ViewModels.Loaders
             // 開始日までの収支を取得する
             decimal balance = await this.mAppService.LoadEndingBalance(bookId, startTime);
 
-            ObservableCollection<SeriesViewModel> vmList = [
-                new SeriesViewModel() {
+            IList<SeriesViewModel> vmList = [
+                new() {
                     OtherName = Properties.Resources.ListName_Balance,
                     Values = [],
                     Periods = []
@@ -259,7 +258,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                 DateOnly tmpEndTime = tmpStartTime.GetLastDateOfFiscalYear(startMonth);
                 tmpPeriod = new(tmpStartTime, tmpEndTime);
             }
-            ObservableCollection<SummaryModel> summaryVMList = [.. await this.mAppService.LoadSummaryListAsync(bookId, tmpPeriod)];
+            IList<SummaryModel> summaryVMList = [.. await this.mAppService.LoadSummaryListAsync(bookId, tmpPeriod)];
             balance += summaryVMList[0].Total;
             vmList[0].Values.Add(balance); // 残高
             vmList[0].Periods.Add(tmpPeriod);

--- a/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
@@ -243,7 +243,7 @@ namespace HouseholdAccountBook.ViewModels
 
             this.ItemList.CollectionChanged += (sender, e) => {
                 if (!this.mOnLoad) {
-                    using FuncLog funcLog = new(level:Log.LogLevel.Debug, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.CollectionChanged)}");
+                    using FuncLog funcLog = new(level: Log.LogLevel.Debug, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.CollectionChanged)}");
                 }
 
                 this.RaisePropertyChanged(nameof(this.Count));
@@ -251,7 +251,7 @@ namespace HouseholdAccountBook.ViewModels
             };
             this.SelectedItemList.CollectionChanged += (sender, e) => {
                 if (!this.mOnLoad) {
-                    using FuncLog funcLog = new(level:Log.LogLevel.Debug, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.SelectedCollectionChanged)}");
+                    using FuncLog funcLog = new(level: Log.LogLevel.Debug, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.SelectedCollectionChanged)}");
                 }
 
                 this.RaisePropertyChanged(nameof(this.SelectedCount));

--- a/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
@@ -31,10 +31,10 @@ namespace HouseholdAccountBook.ViewModels
     }
 
     /// <summary>
-    /// VMリストとその選択VMを保持するVM
+    /// VMリストとその選択VM(リスト)を保持するVM
     /// </summary>
-    /// <typeparam name="VM">VM</typeparam>
-    /// <typeparam name="KEY">VMを特定するキー(IDなど)</typeparam>
+    /// <typeparam name="VM">ViewModel</typeparam>
+    /// <typeparam name="KEY">ViewModelを特定するキー(IDなど)</typeparam>
     public class SelectorViewModel<VM, KEY> : BindableBase, ILoadableAsync, IDisposable
     {
         #region フィールド
@@ -187,11 +187,39 @@ namespace HouseholdAccountBook.ViewModels
         /// 選択 <see cref="VM"/> リスト
         /// </summary>
         /// <remarks>BehaviorにBindするには<see cref="VM"> が <see cref="ISelectable"/> を継承している必要がある</remarks>
-        public ObservableCollection<VM> SelectedItemList { get; } = [];
+        public ObservableCollection<VM>? SelectedItemList {
+            get;
+            set {
+                if (value != null) {
+                    IEnumerable<VM> added = [.. value.Except(field ?? [])];
+                    IEnumerable<VM> removed = [.. field?.Except(value) ?? []];
+
+                    foreach (VM vm in added) {
+                        field?.Add(vm);
+                    }
+                    foreach (VM vm in removed) {
+                        _ = field?.Remove(vm);
+                    }
+                }
+                else {
+                    // null の場合はリストを空にする(ClearだとBehaviorが意図した挙動にならない)
+                    while (0 < (field?.Count ?? 0)) {
+                        field?.RemoveAt(0);
+                    }
+                }
+            }
+        } = [];
         /// <summary>
         /// 選択 <see cref="VM"/> リストのアイテム数
         /// </summary>
-        public int SelectedCount => this.SelectedItemList.Count;
+        public int SelectedCount => this.SelectedItemList?.Count ?? 0;
+        /// <summary>
+        /// 選択 <see cref="KEY"/> リスト
+        /// </summary>
+        public IEnumerable<KEY?> SelectedKeys {
+            get => this.SelectedItemList?.Select(vm => this.mSelector(vm)) ?? [];
+            set => throw new NotImplementedException();
+        }
         #endregion
 
         /// <summary>
@@ -214,13 +242,17 @@ namespace HouseholdAccountBook.ViewModels
             this.mMemberName = memberName;
 
             this.ItemList.CollectionChanged += (sender, e) => {
-                using FuncLog funcLog = new(new { e.OldItems, e.NewItems }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.CollectionChanged)}");
+                if (!this.mOnLoad) {
+                    using FuncLog funcLog = new(level:Log.LogLevel.Debug, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.CollectionChanged)}");
+                }
 
                 this.RaisePropertyChanged(nameof(this.Count));
                 this.CollectionChanged?.Invoke(sender, e);
             };
             this.SelectedItemList.CollectionChanged += (sender, e) => {
-                using FuncLog funcLog = new(new { e.OldItems, e.NewItems }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.SelectedCollectionChanged)}");
+                if (!this.mOnLoad) {
+                    using FuncLog funcLog = new(level:Log.LogLevel.Debug, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.SelectedCollectionChanged)}");
+                }
 
                 this.RaisePropertyChanged(nameof(this.SelectedCount));
                 this.SelectedCollectionChanged?.Invoke(sender, e);
@@ -239,6 +271,7 @@ namespace HouseholdAccountBook.ViewModels
             GC.SuppressFinalize(this);
         }
 
+        private static readonly EqualityComparer<KEY?> mComparer = EqualityComparer<KEY?>.Default;
         /// <summary>
         /// 2 つのキー値が等しいかどうかを判定する
         /// </summary>
@@ -246,7 +279,7 @@ namespace HouseholdAccountBook.ViewModels
         /// <param name="key1">比較する最初のキー値</param>
         /// <param name="key2">比較する 2 番目のキー値</param>
         /// <returns>キー値が等しい場合は <see langword="true"/>。それ以外の場合は <see langword="false"/></returns>
-        private static bool KeyEquals(KEY? key1, KEY? key2) => EqualityComparer<KEY>.Default.Equals(key1, key2);
+        private static bool KeyEquals(KEY? key1, KEY? key2) => mComparer.Equals(key1, key2);
 
         #region SetLoader
         /// <summary>
@@ -313,20 +346,34 @@ namespace HouseholdAccountBook.ViewModels
         private bool CanLoad() => this.mCanLoad?.Invoke() ?? true;
 
         /// <summary>
-        /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
+        /// [非同期] <see cref="VM"/> リストを読込み、現在選択中の <see cref="VM"/> の選択を維持する
         /// </summary>
         /// <param name="token">キャンセル用トークン</param>
         /// <returns></returns>
-        public async Task LoadAsync(CancellationToken token = default) => await this.LoadAsync(default, token);
+        public async Task LoadAsync(CancellationToken token = default) => await this.LoadAsyncCore(default, token);
         /// <summary>
         /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
         /// </summary>
-        /// <param name="selection"><see cref="VM"/> を選択するキー. nullの場合は現在選択中の <see cref="VM"/> を選択する</param>
+        /// <param name="selection"><see cref="VM"/> を選択するキー. nullの場合は現在選択中の <see cref="VM"/> の選択を維持する</param>
         /// <param name="token">キャンセル用トークン</param>
         /// <returns></returns>
-        public async Task LoadAsync(KEY? selection, CancellationToken token = default)
+        public async Task LoadAsync(KEY? selection, CancellationToken token = default) => await this.LoadAsyncCore([selection], token);
+        /// <summary>
+        /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
+        /// </summary>
+        /// <param name="selections"><see cref="VM"/> を選択するキー. nullの場合は現在選択中の <see cref="VM"/> の選択を維持する</param>
+        /// <param name="token">キャンセル用トークン</param>
+        /// <returns></returns>
+        public async Task LoadAsync(IEnumerable<KEY?>? selections, CancellationToken token = default) => await this.LoadAsyncCore(selections, token);
+        /// <summary>
+        /// [非同期] <see cref="VM"/> リストを読込み、指定の <see cref="VM"/> を選択する
+        /// </summary>
+        /// <param name="selections"><see cref="VM"/> を選択するキーのリスト. nullの場合は現在選択中の <see cref="VM"/> の選択を維持する</param>
+        /// <param name="token">キャンセル用トークン</param>
+        /// <returns></returns>
+        protected async Task LoadAsyncCore(IEnumerable<KEY?>? selections, CancellationToken token = default)
         {
-            using FuncLog funcLog = new(new { selection }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(LoadAsync)}");
+            using FuncLog funcLog = new(new { selections }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(LoadAsyncCore)}");
 
             if (this.mLoad is null && this.mLoadAsync is null) { throw new InvalidOperationException(); }
             if (this.mLoad is not null && this.mLoadAsync is not null) { throw new InvalidOperationException(); }
@@ -342,6 +389,7 @@ namespace HouseholdAccountBook.ViewModels
             try {
                 // リスト読込前の値を取得する
                 KEY? oldKey = this.SelectedKey;
+                IEnumerable<KEY?> oldKeys = this.SelectedKeys;
 
                 // 表示するVMを取得する
                 token.ThrowIfCancellationRequested();
@@ -354,8 +402,9 @@ namespace HouseholdAccountBook.ViewModels
                 }
                 token.ThrowIfCancellationRequested();
 
-                // 一旦未選択状態にする
+                // 一旦未選択状態にする(ClearだとBehaviorが意図した挙動にならないのでRemoveAtで空にする)
                 this.SelectedItem = default;
+                this.SelectedItemList = default;
 
                 // 取得したVMを反映する
                 this.ItemList.Clear();
@@ -363,7 +412,8 @@ namespace HouseholdAccountBook.ViewModels
                     this.ItemList.Add(tmp);
                 }
 
-                KEY? tmpSelection = selection ?? oldKey;
+                // 先頭の一つを選択する
+                KEY? tmpSelection = selections != null ? selections.FirstOrDefault() : oldKey;
                 switch (this.mMode) {
                     case SelectorMode.FirstOrElementAtOrDefault:
                         this.SelectedItem = this.ItemList.FirstOrElementAtOrDefault(vm => KeyEquals(this.mSelector(vm), tmpSelection), 0);
@@ -377,6 +427,9 @@ namespace HouseholdAccountBook.ViewModels
                     default:
                         throw new NotSupportedException();
                 }
+                // 全部を選択する
+                IList<KEY?> newKeys = [.. selections ?? oldKeys];
+                this.SelectedItemList = [.. this.ItemList.Where(vm => newKeys.Contains(this.mSelector(vm), mComparer))];
 
                 if (!KeyEquals(this.SelectedKey, oldKey)) {
                     // NULLの場合に通知するか
@@ -419,36 +472,38 @@ namespace HouseholdAccountBook.ViewModels
 
             using IDisposable? disposable = this.mBusyService?.Enter();
 
-            CancellationToken tmpToken = token;
-            if (tmpToken == default) {
-                this.mSelectionCts?.Cancel();
-                this.mSelectionCts?.Dispose();
-                this.mSelectionCts = new();
-                tmpToken = this.mSelectionCts.Token;
-            }
-
             this.SelectionChanged?.Invoke(this, args);
 
-            try {
-                Task[] tasks = [.. this.Children.Select(async c => {
+            if (this.Children.Count != 0) {
+                CancellationToken tmpToken = token;
+                if (tmpToken == default) {
+                    this.mSelectionCts?.Cancel();
+                    this.mSelectionCts?.Dispose();
+                    this.mSelectionCts = new();
+                    tmpToken = this.mSelectionCts.Token;
+                }
+
+                try {
+                    Task[] tasks = [.. this.Children.Select(async c => {
                     tmpToken.ThrowIfCancellationRequested();
                     await c.LoadAsync(tmpToken);
                     tmpToken.ThrowIfCancellationRequested();
                 })];
-                await Task.WhenAll(tasks);
-            }
-            catch (OperationCanceledException) {
-                Log.Debug($"{this.mMemberName}.{nameof(OnSelectionChangedAsync)} Canceled.");
-                // キャンセル用トークンが引数で与えられていた場合は再スロー
-                if (token != default) {
-                    throw;
+                    await Task.WhenAll(tasks);
+                }
+                catch (OperationCanceledException) {
+                    Log.Debug($"{this.mMemberName}.{nameof(OnSelectionChangedAsync)} Canceled.");
+                    // キャンセル用トークンが引数で与えられていた場合は再スロー
+                    if (token != default) {
+                        throw;
+                    }
                 }
             }
         }
     }
 
     /// <summary>
-    /// コンストラクタ
+    /// VMリストとその選択VM(リスト)を保持するVM
     /// </summary>
     /// <param name="busyService">処理中状態サービス</param>
     /// <param name="itemChangedIfNull">選択 <see cref="VM"/> がNullの場合でも変更を通知するか</param>

--- a/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/SelectorViewModel.cs
@@ -6,6 +6,7 @@ using HouseholdAccountBook.ViewModels.Abstract;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -88,9 +89,17 @@ namespace HouseholdAccountBook.ViewModels
 
         #region イベント
         /// <summary>
+        /// <see cref="VM"/> リスト変更時イベント
+        /// </summary>
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+        /// <summary>
         /// 選択 <see cref="VM"> 変更時イベント
         /// </summary>
         public event EventHandler<ChangedEventArgs<KEY>>? SelectionChanged;
+        /// <summary>
+        /// 選択 <see cref="VM"/> リスト変更時イベント
+        /// </summary>
+        public event NotifyCollectionChangedEventHandler? SelectedCollectionChanged;
         #endregion
 
         #region プロパティ
@@ -173,12 +182,22 @@ namespace HouseholdAccountBook.ViewModels
             get => this.SelectedItem == null ? -1 : this.ItemList.IndexOf(this.SelectedItem);
             set => this.SelectedItem = (value < 0 || this.ItemList.Count <= value) ? default : this.ItemList[value];
         }
+
+        /// <summary>
+        /// 選択 <see cref="VM"/> リスト
+        /// </summary>
+        /// <remarks>BehaviorにBindするには<see cref="VM"> が <see cref="ISelectable"/> を継承している必要がある</remarks>
+        public ObservableCollection<VM> SelectedItemList { get; } = [];
+        /// <summary>
+        /// 選択 <see cref="VM"/> リストのアイテム数
+        /// </summary>
+        public int SelectedCount => this.SelectedItemList.Count;
         #endregion
 
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        /// <param name="selector"><see cref="KEY"/><see cref="VM"/> から <see cref="KEY"/> への変換処理</param>
+        /// <param name="selector"><see cref="VM"/> から <see cref="KEY"/> への変換処理</param>
         /// <param name="busyService">処理中状態サービス</param>
         /// <param name="itemChangedIfNull">選択 <see cref="VM"/> がNullの場合でも変更を通知するか</param>
         /// <param name="fileName">出力元ファイル名</param>
@@ -186,8 +205,6 @@ namespace HouseholdAccountBook.ViewModels
         public SelectorViewModel(Func<VM?, KEY?> selector, BusyService? busyService = null, bool itemChangedIfNull = false,
                                  [CallerFilePath] string? fileName = null, [CallerMemberName] string memberName = "")
         {
-            ArgumentNullException.ThrowIfNull(selector);
-
             using FuncLog funcLog = new(level: Log.LogLevel.Trace, fileName: fileName, methodName: memberName);
 
             this.mSelector = selector;
@@ -195,6 +212,19 @@ namespace HouseholdAccountBook.ViewModels
             this.mItemChangedIfNull = itemChangedIfNull;
             this.mFileName = fileName;
             this.mMemberName = memberName;
+
+            this.ItemList.CollectionChanged += (sender, e) => {
+                using FuncLog funcLog = new(new { e.OldItems, e.NewItems }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.CollectionChanged)}");
+
+                this.RaisePropertyChanged(nameof(this.Count));
+                this.CollectionChanged?.Invoke(sender, e);
+            };
+            this.SelectedItemList.CollectionChanged += (sender, e) => {
+                using FuncLog funcLog = new(new { e.OldItems, e.NewItems }, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(this.SelectedCollectionChanged)}");
+
+                this.RaisePropertyChanged(nameof(this.SelectedCount));
+                this.SelectedCollectionChanged?.Invoke(sender, e);
+            };
         }
 
         ~SelectorViewModel()
@@ -218,6 +248,7 @@ namespace HouseholdAccountBook.ViewModels
         /// <returns>キー値が等しい場合は <see langword="true"/>。それ以外の場合は <see langword="false"/></returns>
         private static bool KeyEquals(KEY? key1, KEY? key2) => EqualityComparer<KEY>.Default.Equals(key1, key2);
 
+        #region SetLoader
         /// <summary>
         /// <see cref="VM"> リスト読込処理を設定する
         /// </summary>
@@ -273,11 +304,12 @@ namespace HouseholdAccountBook.ViewModels
             this.mLoadAsync = loadAsync;
             this.mMode = mode;
         }
+        #endregion
 
         /// <summary>
         /// 読込み可能か
         /// </summary>
-        /// <returns></returns>
+        /// <returns>読込み可能/不可能</returns>
         private bool CanLoad() => this.mCanLoad?.Invoke() ?? true;
 
         /// <summary>
@@ -378,6 +410,12 @@ namespace HouseholdAccountBook.ViewModels
         {
             ChangedEventArgs<KEY> args = new() { OldValue = oldKey, NewValue = newKey };
             using FuncLog funcLog = new(args, fileName: this.mFileName, methodName: $"{this.mMemberName}.{nameof(OnSelectionChangedAsync)}");
+
+            // 変更時に外部に作用する要素がなければ処理しない(BusyService.Enterを防ぐ)
+            if (this.SelectionChanged is null && this.Children.Count is 0) {
+                Log.Debug("Nothing to do.");
+                return;
+            }
 
             using IDisposable? disposable = this.mBusyService?.Enter();
 

--- a/HouseholdAccountBook/ViewModels/Windows/CsvComparisonWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/CsvComparisonWindowViewModel.cs
@@ -92,9 +92,9 @@ namespace HouseholdAccountBook.ViewModels.Windows
         public BookIdObj SelectedBookId {
             get => this.BookSelectorVM.SelectedKey;
             set {
-                BookIdObj oldValue = this.SelectedBookId;
+                BookIdObj oldValue = this.BookSelectorVM.SelectedKey;
                 // 現在の選択と異なる場合
-                if (this.BookSelectorVM.SelectedKey != value) {
+                if (oldValue != value) {
                     this.BookSelectorVM.SelectedKey = value;
                     // 当てはまる帳簿がなく現在の選択と同じになった場合に変更イベントを発行する
                     if (oldValue == this.BookSelectorVM.SelectedKey) {
@@ -113,30 +113,18 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public int AllCheckedCount => this.CsvCompSelectorVM.ItemList.Count(static vm => vm.IsMatch);
         /// <summary>
-        /// CSV比較VMの個数
-        /// </summary>
-        public int AllCount => this.CsvCompSelectorVM.ItemList.Count;
-        /// <summary>
         /// CSV比較VMの合計値
         /// </summary>
         public int AllSumValue => this.CsvCompSelectorVM.ItemList.Sum(static vm => vm.Record.Value);
 
         /// <summary>
-        /// 選択されたCSV比較VMリスト
-        /// </summary>
-        public ObservableCollection<CsvComparisonViewModel> SelectedCsvCompVMList { get; } = [];
-        /// <summary>
         /// 選択されたCSV比較VMのチェック数
         /// </summary>
-        public int SelectedCheckedCount => this.SelectedCsvCompVMList.Count(static vm => vm.IsMatch);
-        /// <summary>
-        /// 選択されたCSV比較VMの個数
-        /// </summary>
-        public int SelectedCount => this.SelectedCsvCompVMList.Count;
+        public int SelectedCheckedCount => this.CsvCompSelectorVM.SelectedItemList.Count(static vm => vm.IsMatch);
         /// <summary>
         /// 選択されたCSV比較VMの合計値
         /// </summary>
-        public int SelectedSumValue => this.SelectedCsvCompVMList.Sum(static vm => vm.Record.Value);
+        public int SelectedSumValue => this.CsvCompSelectorVM.SelectedItemList.Sum(static vm => vm.Record.Value);
 
         /// <summary>
         /// チェック数変更を通知する
@@ -279,13 +267,13 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         /// <returns></returns>
         /// <remarks>選択されているCSVデータが1つ以上存在していて、帳簿に紐づかない項目が1つ以上ある</remarks>
-        private bool AddActionCommand_CanExecute() => this.SelectedCsvCompVMList.Count != 0 && this.SelectedCsvCompVMList.Any(vm => vm.Action is null);
+        private bool AddActionCommand_CanExecute() => this.CsvCompSelectorVM.SelectedCount != 0 && this.CsvCompSelectorVM.SelectedItemList.Any(vm => vm.Action is null);
         /// <summary>
         /// 帳簿項目追加コマンド処理
         /// </summary>
         private void AddActionCommand_Execute()
         {
-            List<CsvComparisonViewModel> vmList = [.. this.SelectedCsvCompVMList.Where(vm => vm.Action is null)];
+            List<CsvComparisonViewModel> vmList = [.. this.CsvCompSelectorVM.SelectedItemList.Where(vm => vm.Action is null)];
             List<ActionCsvDto> recordList = [.. vmList.Select(vm => vm.Record)];
 
             async void Registered(object sender, EventArgs<IEnumerable<ActionIdObj>> e)
@@ -328,7 +316,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         /// <returns></returns>
         /// <remarks>選択されているCSVデータが1つだけ存在していて、帳簿項目に紐づいている</remarks>
-        private bool EditActionCommand_CanExecute() => this.SelectedCsvCompVMList.Count == 1 && this.CsvCompSelectorVM.SelectedItem.Action is not null;
+        private bool EditActionCommand_CanExecute() => this.CsvCompSelectorVM.SelectedCount == 1 && this.CsvCompSelectorVM.SelectedItem.Action is not null;
         /// <summary>
         /// 帳簿項目編集コマンド処理
         /// </summary>
@@ -383,7 +371,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         private async Task AddOrEditActionCommand_ExecuteAsync()
         {
             // 選択されているCSVデータが1つ以上存在していて、帳簿項目に紐づかない項目が1つ以上ある
-            if (0 < this.SelectedCsvCompVMList.Count && this.SelectedCsvCompVMList.Any(vm => vm.Action is null)) {
+            if (0 < this.CsvCompSelectorVM.SelectedCount && this.CsvCompSelectorVM.SelectedItemList.Any(vm => vm.Action is null)) {
                 this.AddActionCommand_Execute();
             }
             else {
@@ -491,11 +479,14 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
                 this.RaisePropertyChanged(nameof(this.CsvFilePathes));
             };
-            this.CsvCompSelectorVM.ItemList.CollectionChanged += (sender, e) => {
-                using FuncLog funcLog = new(new { e.OldItems, e.NewItems }, methodName: nameof(this.CsvCompSelectorVM.ItemList.CollectionChanged));
+            this.BookSelectorVM.SelectionChanged += async (sender, e) => {
+                this.BookChanged?.Invoke(sender, e);
 
+                await this.ReloadCsvFilesAsync();
+                await this.UpdateComparisonVMListAsync(true);
+            };
+            this.CsvCompSelectorVM.CollectionChanged += (sender, e) => {
                 this.RaisePropertyChanged(nameof(this.AllCheckedCount));
-                this.RaisePropertyChanged(nameof(this.AllCount));
                 this.RaisePropertyChanged(nameof(this.AllSumValue));
 
                 if (e.OldItems != null) {
@@ -513,18 +504,8 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     }
                 }
             };
-            this.BookSelectorVM.SelectionChanged += async (sender, e) => {
-                this.BookChanged?.Invoke(sender, e);
-
-                await this.ReloadCsvFilesAsync();
-                await this.UpdateComparisonVMListAsync(true);
-            };
-
-            this.SelectedCsvCompVMList.CollectionChanged += (sender, e) => {
-                using FuncLog funcLog = new(new { e.OldItems, e.NewItems }, methodName: nameof(this.SelectedCsvCompVMList.CollectionChanged));
-
+            this.CsvCompSelectorVM.SelectedCollectionChanged += (sender, e) => {
                 this.RaisePropertyChanged(nameof(this.SelectedCheckedCount));
-                this.RaisePropertyChanged(nameof(this.SelectedCount));
                 this.RaisePropertyChanged(nameof(this.SelectedSumValue));
             };
         }

--- a/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
@@ -386,12 +386,12 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 表示月リスト(月別一覧の月)
         /// </summary>
-        public ObservableCollection<DateOnly> DisplayedMonths {
+        public IList<DateOnly> DisplayedMonths {
             get {
                 DateOnly tmpMonth = this.DisplayedYear.GetFirstDateOfFiscalYear(this.FiscalStartMonth);
 
                 // 表示する月の文字列を作成する
-                ObservableCollection<DateOnly> displayedMonths = [];
+                IList<DateOnly> displayedMonths = [];
                 for (int i = 0; i < 12; ++i) {
                     displayedMonths.Add(tmpMonth);
                     tmpMonth = tmpMonth.AddMonths(1);
@@ -411,10 +411,10 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 表示年リスト(年別一覧の年)
         /// </summary>
-        public ObservableCollection<DateOnly> DisplayedYears {
+        public IList<DateOnly> DisplayedYears {
             get {
                 DateOnly tmpYear = this.DisplayedYear.GetFirstDateOfFiscalYear(this.FiscalStartMonth).AddYears(-9);
-                ObservableCollection<DateOnly> displayedYears = [];
+                IList<DateOnly> displayedYears = [];
                 for (int i = 0; i < 10; ++i) {
                     displayedYears.Add(tmpYear);
                     tmpYear = tmpYear.AddYears(1);

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowBookTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowBookTabViewModel.cs
@@ -14,10 +14,11 @@ using HouseholdAccountBook.ViewModels.Component;
 using HouseholdAccountBook.ViewModels.Windows;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace HouseholdAccountBook.ViewModels.WindowsParts
@@ -25,9 +26,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
     /// <summary>
     /// メインウィンドウ 帳簿項目タブVM
     /// </summary>
-    /// <param name="parent">親VM</param>
-    /// <param name="tab">タブ</param>
-    public class MainWindowBookTabViewModel(MainWindowViewModel parent, Tabs tab) : WindowPartViewModelBase
+    public class MainWindowBookTabViewModel : WindowPartViewModelBase
     {
         #region フィールド
         /// <summary>
@@ -43,9 +42,9 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 親VM
         /// </summary>
-        private MainWindowViewModel Parent { get; } = parent;
+        private MainWindowViewModel Parent { get; init; }
 
-        private Tabs Tab { get; } = tab;
+        private Tabs Tab { get; init; }
 
         #region イベント
         /// <summary>
@@ -101,10 +100,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 表示対象の帳簿項目VMリスト
         /// </summary>
-        public ObservableCollection<ActionViewModel> DisplayedActionVMList {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
+        public ICollectionView FilteredActionVMList { get; init; }
 
         /// <summary>
         /// CSVと一致したか
@@ -171,7 +167,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             get;
             set {
                 if (this.SetProperty(ref field, value)) {
-                    this.UpdateDisplayedActionVMList();
+                    this.RefreshFilteredActionVMList();
                 }
             }
         }
@@ -206,7 +202,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             get;
             set {
                 if (this.SetProperty(ref field, value)) {
-                    this.UpdateDisplayedActionVMList();
+                    this.RefreshFilteredActionVMList();
                 }
             }
         } = string.Empty;
@@ -284,7 +280,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             }
 
             List<ActionIdObj> actionIdList = [];
-            foreach (ActionViewModel vm in this.DisplayedActionVMList) {
+            foreach (ActionViewModel vm in this.FilteredActionVMList) {
                 actionIdList.Add(vm.ActionId);
 
                 string shopName = vm.Shop?.Replace(this.FindText, this.ReplaceText);
@@ -509,39 +505,60 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         public void RaiseCurrentBackUpChanged() => this.RaisePropertyChanged(nameof(this.CurrentBackUp));
 
         /// <summary>
-        /// <see cref="DisplayedActionVMList"/> を更新する
+        /// <see cref="FilteredActionVMList"/> を更新する
         /// </summary>
-        /// <remarks>表示されている項目のみ選択する</remarks>
-        private void UpdateDisplayedActionVMList()
+        private void RefreshFilteredActionVMList()
         {
-            using FuncLog funcLog = new();
+            this.FilteredActionVMList.Refresh();
+            // 選択項目を表示項目に限定する
+            this.ActionSelectorVM.SelectedItemList = [.. this.ActionSelectorVM.SelectedItemList.Where(vm => this.FilteredActionVMList.Contains(vm))];
+        }
+        /// <summary>
+        /// <see cref="FilteredActionVMList"/> のフィルタ
+        /// </summary>
+        /// <param name="obj">フィルタ対象のVM</param>
+        private bool ActionVMListFilter(object obj)
+        {
+            if (obj is not ActionViewModel vm) { return false; }
 
-            ObservableCollection<ActionViewModel> tmp = this.ActionSelectorVM.ItemList;
+            bool result = true;
 
             if (this.UseFilter) {   // フィルタ有効の場合
-                // 概要が選択されている場合
-                if (this.SummarySelectorVM.SelectedKey.HasValue) {
+                if (this.SummarySelectorVM.SelectedKey.HasValue) { // 概要が選択されている場合
                     (BalanceKind?, CategoryIdObj, ItemIdObj) selectedKey = this.SummarySelectorVM.SelectedKey.Value;
-                    // 収支が選択されている場合
-                    if (selectedKey.Item1 != BalanceKind.Others) {
-                        tmp = selectedKey.Item2 == CategoryIdObj.System // 分類が選択されていない場合
-                            ? [.. tmp.Where(vm => vm.BalanceKind == selectedKey.Item1 || vm.ActionId == ActionIdObj.System)]
-                            : selectedKey.Item3 == ItemIdObj.System // 項目が選択されていない場合
-                                ? [.. tmp.Where(vm => vm.CategoryId == selectedKey.Item2 || vm.ActionId == ActionIdObj.System)]
-                                : [.. tmp.Where(vm => vm.ItemId == selectedKey.Item3 || vm.ActionId == ActionIdObj.System)];
+
+                    if (selectedKey.Item1 != BalanceKind.Others) { // 収支が選択されている場合
+                        result &= selectedKey.Item2 == CategoryIdObj.System // 分類が選択されていない場合
+                                ? vm.BalanceKind == selectedKey.Item1 || vm.ActionId == ActionIdObj.System
+                                : selectedKey.Item3 == ItemIdObj.System // 項目が選択されていない場合
+                                   ? vm.CategoryId == selectedKey.Item2 || vm.ActionId == ActionIdObj.System
+                                   : vm.ItemId == selectedKey.Item3 || vm.ActionId == ActionIdObj.System;
                     }
                 }
             }
 
             // 検索テキストで絞り込む
             if (this.FindText != string.Empty) {
-                tmp = [.. tmp.Where(vm => (vm.Shop?.Contains(this.FindText) ?? false) || (vm.Remark?.Contains(this.FindText) ?? false))];
+                result &= (vm.Shop?.Contains(this.FindText) ?? false) || (vm.Remark?.Contains(this.FindText) ?? false);
             }
 
-            this.DisplayedActionVMList = tmp;
+            return result;
+        }
 
-            // 選択項目を表示項目に限定する
-            this.ActionSelectorVM.SelectedItemList = [.. this.ActionSelectorVM.SelectedItemList.Where(vm => this.DisplayedActionVMList.Contains(vm))];
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="parent">親VM</param>
+        /// <param name="tab">タブ</param>
+        public MainWindowBookTabViewModel(MainWindowViewModel parent, Tabs tab)
+        {
+            using FuncLog funcLog = new(new { tab });
+
+            this.Parent = parent;
+            this.Tab = tab;
+
+            this.FilteredActionVMList = CollectionViewSource.GetDefaultView(this.ActionSelectorVM.ItemList);
+            this.FilteredActionVMList.Filter = this.ActionVMListFilter;
         }
 
         public override void Initialize(BusyService busyService, DbHandlerFactory dbHandlerFactory)
@@ -596,7 +613,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                 this.SummarySelectorVM.LoadAsync((tmpBalanceKind, tmpCategoryId, tmpItemId))
             ];
             await Task.WhenAll(tasks);
-            this.UpdateDisplayedActionVMList();
+            this.RefreshFilteredActionVMList();
 
             if (isScroll) {
                 if (this.Parent.DisplayedPeriodKind == PeriodKind.Monthly &&
@@ -633,7 +650,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             this.SummarySelectorVM.SelectionChanged += (sender, e) => {
                 this.SelectedSeriesChanged?.Invoke(this, e);
 
-                this.UpdateDisplayedActionVMList();
+                this.RefreshFilteredActionVMList();
             };
         }
 

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowBookTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowBookTabViewModel.cs
@@ -94,15 +94,10 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
 
         #region Bindingプロパティ
         /// <summary>
-        /// 帳簿項目VMリスト
+        /// 帳簿項目セレクタVM
         /// </summary>
-        public ObservableCollection<ActionViewModel> ActionVMList {
-            get;
-            set {
-                _ = this.SetProperty(ref field, value);
-                this.UpdateDisplayedActionVMList();
-            }
-        }
+        public SelectorViewModel<ActionViewModel, ActionIdObj> ActionSelectorVM => field ??= new(static vm => vm?.ActionId, this.mBusyService);
+
         /// <summary>
         /// 表示対象の帳簿項目VMリスト
         /// </summary>
@@ -112,52 +107,19 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         }
 
         /// <summary>
-        /// 選択された帳簿項目VM(先頭)
-        /// </summary>
-        public ActionViewModel SelectedActionVM {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
-        /// <summary>
-        /// 選択された帳簿項目VMリスト
-        /// </summary>
-        public ObservableCollection<ActionViewModel> SelectedActionVMList {
-            get;
-            set {
-                if (value != null) {
-                    IEnumerable<ActionViewModel> added = [.. value.Except(field)];
-                    IEnumerable<ActionViewModel> removed = [.. field.Except(value)];
-
-                    foreach (ActionViewModel vm in added) {
-                        field.Add(vm);
-                    }
-                    foreach (ActionViewModel vm in removed) {
-                        _ = field.Remove(vm);
-                    }
-                }
-                else {
-                    // null の場合はリストを空にする(ClearだとBehaviorが意図した挙動にならない)
-                    while (0 < field.Count) {
-                        field.RemoveAt(0);
-                    }
-                }
-            }
-        } = [];
-
-        /// <summary>
         /// CSVと一致したか
         /// </summary>
         public bool? IsMatch {
             get {
-                int count = this.SelectedActionVMList.Count(vm => vm.IsMatch);
+                int count = this.ActionSelectorVM.SelectedItemList.Count(vm => vm.IsMatch);
                 return count switch {
                     0 => false,
-                    _ => count == this.SelectedActionVMList.Count ? true : null,
+                    _ => count == this.ActionSelectorVM.SelectedCount ? true : null,
                 };
             }
             set {
                 if (value.HasValue) {
-                    foreach (ActionViewModel vm in this.SelectedActionVMList) {
+                    foreach (ActionViewModel vm in this.ActionSelectorVM.SelectedItemList) {
                         vm.IsMatch = value.Value;
                     }
                 }
@@ -183,7 +145,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 選択されたデータの個数
         /// </summary>
-        public int Count => this.SelectedActionVMList.Count(static vm => vm.ActionWithBalance.Action.Category.BalanceKind != BalanceKind.Others);
+        public int Count => this.ActionSelectorVM.SelectedItemList.Count(static vm => vm.BalanceKind != BalanceKind.Others);
         /// <summary>
         /// 選択されたデータの合計値
         /// </summary>
@@ -191,11 +153,11 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 選択されたデータの収入合計値
         /// </summary>
-        public decimal IncomeSumValue => this.SelectedActionVMList.Sum(static vm => vm.ActionWithBalance.Action.Category.BalanceKind == BalanceKind.Income ? vm.ActionWithBalance.Action.Amount : 0);
+        public decimal IncomeSumValue => this.ActionSelectorVM.SelectedItemList.Sum(static vm => vm.BalanceKind == BalanceKind.Income ? vm.Amount : 0);
         /// <summary>
         /// 選択されたデータの支出合計値
         /// </summary>
-        public decimal ExpensesSumValue => this.SelectedActionVMList.Sum(static vm => vm.ActionWithBalance.Action.Category.BalanceKind == BalanceKind.Expenses ? vm.ActionWithBalance.Action.Amount : 0);
+        public decimal ExpensesSumValue => this.ActionSelectorVM.SelectedItemList.Sum(static vm => vm.BalanceKind == BalanceKind.Expenses ? vm.Amount : 0);
 
         /// <summary>
         /// 概要セレクタVM
@@ -323,12 +285,12 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
 
             List<ActionIdObj> actionIdList = [];
             foreach (ActionViewModel vm in this.DisplayedActionVMList) {
-                actionIdList.Add(vm.ActionWithBalance.Action.ActionId);
+                actionIdList.Add(vm.ActionId);
 
-                string shopName = vm.ActionWithBalance.Action.Shop.Name.Replace(this.FindText, this.ReplaceText);
-                string remark = vm.ActionWithBalance.Action.Remark.Remark.Replace(this.FindText, this.ReplaceText);
+                string shopName = vm.Shop?.Replace(this.FindText, this.ReplaceText);
+                string remark = vm.Remark?.Replace(this.FindText, this.ReplaceText);
 
-                await this.mMainService.UpdateShopNameAndRemarkInActionAsync(vm.ActionWithBalance.Action.ActionId, shopName, remark);
+                await this.mMainService.UpdateShopNameAndRemarkInActionAsync(vm.ActionId, shopName, remark);
             }
 
             this.FindText = string.Empty; // 検索をクリアしておく
@@ -351,7 +313,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                 DbHandlerFactory = this.mDbHandlerFactory,
                 InitialBookId = this.Parent.BookSelectorVM?.SelectedKey,
                 InitialMonth = this.Parent.DisplayedPeriodKind == PeriodKind.Monthly ? this.Parent.DisplayedMonth : null,
-                InitialDate = this.SelectedActionVM is null ? null : DateOnly.FromDateTime(this.SelectedActionVM.ActionWithBalance.Action.Base.ActTime),
+                InitialDate = this.ActionSelectorVM.SelectedItem is null ? null : DateOnly.FromDateTime(this.ActionSelectorVM.SelectedItem.ActTime),
                 Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
             };
             this.AddMoveRequested?.Invoke(this, e);
@@ -373,7 +335,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                 DbHandlerFactory = this.mDbHandlerFactory,
                 InitialBookId = this.Parent.BookSelectorVM?.SelectedKey,
                 InitialMonth = this.Parent.DisplayedPeriodKind == PeriodKind.Monthly ? this.Parent.DisplayedMonth : null,
-                InitialDate = this.SelectedActionVM is null ? null : DateOnly.FromDateTime(this.SelectedActionVM.ActionWithBalance.Action.Base.ActTime),
+                InitialDate = this.ActionSelectorVM.SelectedItem is null ? null : DateOnly.FromDateTime(this.ActionSelectorVM.SelectedItem.ActTime),
                 Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true)  // 帳簿一覧タブを更新する
             };
             this.AddActionRequested?.Invoke(this, e);
@@ -395,7 +357,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                 DbHandlerFactory = this.mDbHandlerFactory,
                 InitialBookId = this.Parent.BookSelectorVM?.SelectedKey,
                 InitialMonth = this.Parent.DisplayedPeriodKind == PeriodKind.Monthly ? this.Parent.DisplayedMonth : null,
-                InitialDate = this.SelectedActionVM is null ? null : DateOnly.FromDateTime(this.SelectedActionVM.ActionWithBalance.Action.Base.ActTime),
+                InitialDate = this.ActionSelectorVM.SelectedItem is null ? null : DateOnly.FromDateTime(this.ActionSelectorVM.SelectedItem.ActTime),
                 Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
             };
             this.AddActionListRequested?.Invoke(this, e);
@@ -408,14 +370,14 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         public ICommand CopyCommand => field ??= new AsyncRelayCommand(
             this.CopyCommand_ExecuteAsync,
             () => this.Parent.SelectedTab == Tabs.BooksTab &&
-                  this.SelectedActionVMList.Count == 1 && 0 < (int)(this.SelectedActionVM?.ActionWithBalance.Action.ActionId ?? 0) && !this.Parent.IsChildrenWindowOpened());
+                  this.ActionSelectorVM.SelectedCount == 1 && 0 < (int)(this.ActionSelectorVM.SelectedKey ?? 0) && !this.Parent.IsChildrenWindowOpened());
         /// <summary>
         /// 複製コマンド処理
         /// </summary>
         private async Task CopyCommand_ExecuteAsync()
         {
             // グループ種別を特定する
-            GroupKind kind = await this.mAppService.LoadGroupKind(this.SelectedActionVM.ActionWithBalance.Action.ActionId);
+            GroupKind kind = await this.mAppService.LoadGroupKind(this.ActionSelectorVM.SelectedKey);
 
             switch (kind) {
                 case GroupKind.NotInOne:
@@ -424,7 +386,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                     // 移動以外の帳簿項目の複製時の処理
                     CopyActionRequestEventArgs e = new() {
                         DbHandlerFactory = this.mDbHandlerFactory,
-                        TargetActionId = this.SelectedActionVM.ActionWithBalance.Action.ActionId,
+                        TargetActionId = this.ActionSelectorVM.SelectedKey,
                         Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
                     };
                     this.CopyActionRequested?.Invoke(this, e);
@@ -434,7 +396,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                     // 移動の複製時の処理
                     CopyMoveRequestEventArgs e = new() {
                         DbHandlerFactory = this.mDbHandlerFactory,
-                        TargetGroupId = this.SelectedActionVM.ActionWithBalance.Action.GroupId,
+                        TargetGroupId = this.ActionSelectorVM.SelectedItem.GroupId,
                         Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
                     };
                     this.CopyMoveRequested?.Invoke(this, e);
@@ -452,21 +414,21 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         public ICommand EditCommand => field ??= new AsyncRelayCommand(
             this.EditCommand_ExecuteAsync,
             () => this.Parent.SelectedTab == Tabs.BooksTab &&
-                  this.SelectedActionVMList.Count == 1 && 0 < (int)(this.SelectedActionVM?.ActionWithBalance.Action.ActionId ?? 0) && !this.Parent.IsChildrenWindowOpened());
+                  this.ActionSelectorVM.SelectedCount == 1 && 0 < (int)(this.ActionSelectorVM?.SelectedKey ?? 0) && !this.Parent.IsChildrenWindowOpened());
         /// <summary>
         /// 編集コマンド処理
         /// </summary>
         private async Task EditCommand_ExecuteAsync()
         {
             // グループ種別を特定する
-            GroupKind kind = await this.mAppService.LoadGroupKind(this.SelectedActionVM.ActionWithBalance.Action.ActionId);
+            GroupKind kind = await this.mAppService.LoadGroupKind(this.ActionSelectorVM.SelectedKey);
 
             switch (kind) {
                 case GroupKind.Move: {
                     // 移動の編集時の処理
                     EditMoveRequestEventArgs e = new() {
                         DbHandlerFactory = this.mDbHandlerFactory,
-                        TargetGroupId = this.SelectedActionVM.ActionWithBalance.Action.GroupId,
+                        TargetGroupId = this.ActionSelectorVM.SelectedItem.GroupId,
                         Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
                     };
                     this.EditMoveRequested?.Invoke(this, e);
@@ -476,7 +438,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                     // リスト登録された帳簿項目の編集時の処理
                     EditActionListRequestEventArgs e = new() {
                         DbHandlerFactory = this.mDbHandlerFactory,
-                        TargetGroupId = this.SelectedActionVM.ActionWithBalance.Action.GroupId,
+                        TargetGroupId = this.ActionSelectorVM.SelectedItem.GroupId,
                         Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
                     };
                     this.EditActionListRequested?.Invoke(this, e);
@@ -488,7 +450,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                     // 移動・リスト登録以外の帳簿項目の編集時の処理
                     EditActionRequestEventArgs e = new() {
                         DbHandlerFactory = this.mDbHandlerFactory,
-                        TargetActionId = this.SelectedActionVM.ActionWithBalance.Action.ActionId,
+                        TargetActionId = this.ActionSelectorVM.SelectedKey,
                         Registered = async (sender, e) => await this.LoadAsync(e.Value, isUpdateActDateLastEdited: true) // 帳簿一覧タブを更新する
                     };
                     this.EditActionRequested?.Invoke(this, e);
@@ -504,7 +466,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         public ICommand DeleteCommand => field ??= new AsyncRelayCommand(
             this.DeleteCommand_ExecuteAsync,
             () => this.Parent.SelectedTab == Tabs.BooksTab &&
-                  this.SelectedActionVMList.Any(static vm => 0 < (int)vm.ActionWithBalance.Action.ActionId) && !this.Parent.IsChildrenWindowOpened());
+                  this.ActionSelectorVM.SelectedItemList.Any(static vm => 0 < (int)vm.ActionId) && !this.Parent.IsChildrenWindowOpened());
         /// <summary>
         /// 削除コマンド処理
         /// </summary>
@@ -513,7 +475,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             if (MessageBox.Show(Properties.Resources.Message_DeleteNotification, Properties.Resources.Title_Conformation,
                 MessageBoxButton.OKCancel, MessageBoxImage.Question, MessageBoxResult.Cancel) == MessageBoxResult.OK) {
 
-                IEnumerable<(ActionIdObj, GroupIdObj)> targetList = this.SelectedActionVMList.Where(vm => 0 < vm.ActionWithBalance.Action.ActionId.Id).Select(vm => (vm.ActionId, vm.GroupId));
+                IEnumerable<(ActionIdObj, GroupIdObj)> targetList = this.ActionSelectorVM.SelectedItemList.Where(vm => 0 < vm.ActionId.Id).Select(vm => (vm.ActionId, vm.GroupId));
                 await this.mMainService.DeleteAction(targetList);
 
                 // 帳簿一覧タブを更新する
@@ -528,15 +490,15 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         public ICommand ChangeIsMatchCommand => field ??= new AsyncRelayCommand(
             this.ChangeIsMatchCommand_ExecuteAsync,
             () => this.Parent.SelectedTab == Tabs.BooksTab &&
-                  this.SelectedActionVMList.Any(vm => 0 < (int)vm.ActionWithBalance.Action.ActionId) && !this.Parent.IsRegistrationWindowOpened());
+                  this.ActionSelectorVM.SelectedItemList.Any(vm => 0 < (int)vm.ActionId) && !this.Parent.IsRegistrationWindowOpened());
         /// <summary>
         /// 一致フラグ変更コマンド処理
         /// </summary>
         private async Task ChangeIsMatchCommand_ExecuteAsync()
         {
             // 帳簿項目IDが0を超える項目についてループ
-            foreach (ActionViewModel vm in this.SelectedActionVMList.Where(vm => 0 < (int)vm.ActionWithBalance.Action.ActionId)) {
-                await this.mAppService.SaveIsMatchAsync(vm.ActionWithBalance.Action.ActionId, vm.IsMatch);
+            foreach (ActionViewModel vm in this.ActionSelectorVM.SelectedItemList.Where(vm => 0 < (int)vm.ActionId)) {
+                await this.mAppService.SaveIsMatchAsync(vm.ActionId, vm.IsMatch);
             }
         }
         #endregion
@@ -554,32 +516,32 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         {
             using FuncLog funcLog = new();
 
-            ObservableCollection<ActionViewModel> tmp = this.ActionVMList;
+            ObservableCollection<ActionViewModel> tmp = this.ActionSelectorVM.ItemList;
 
             if (this.UseFilter) {   // フィルタ有効の場合
                 // 概要が選択されている場合
                 if (this.SummarySelectorVM.SelectedKey.HasValue) {
-                    var selectedKey = this.SummarySelectorVM.SelectedKey.Value;
+                    (BalanceKind?, CategoryIdObj, ItemIdObj) selectedKey = this.SummarySelectorVM.SelectedKey.Value;
                     // 収支が選択されている場合
                     if (selectedKey.Item1 != BalanceKind.Others) {
                         tmp = selectedKey.Item2 == CategoryIdObj.System // 分類が選択されていない場合
-                            ? [.. tmp.Where(vm => vm.ActionWithBalance.Action.Category.BalanceKind == selectedKey.Item1 || vm.ActionWithBalance.Action.ActionId == ActionIdObj.System)]
+                            ? [.. tmp.Where(vm => vm.BalanceKind == selectedKey.Item1 || vm.ActionId == ActionIdObj.System)]
                             : selectedKey.Item3 == ItemIdObj.System // 項目が選択されていない場合
-                                ? [.. tmp.Where(vm => vm.ActionWithBalance.Action.Category.Id == selectedKey.Item2 || vm.ActionWithBalance.Action.ActionId == ActionIdObj.System)]
-                                : [.. tmp.Where(vm => vm.ActionWithBalance.Action.Item.Id == selectedKey.Item3 || vm.ActionWithBalance.Action.ActionId == ActionIdObj.System)];
+                                ? [.. tmp.Where(vm => vm.CategoryId == selectedKey.Item2 || vm.ActionId == ActionIdObj.System)]
+                                : [.. tmp.Where(vm => vm.ItemId == selectedKey.Item3 || vm.ActionId == ActionIdObj.System)];
                     }
                 }
             }
 
             // 検索テキストで絞り込む
             if (this.FindText != string.Empty) {
-                tmp = [.. tmp.Where(vm => (vm.ActionWithBalance.Action.Shop?.Name.Contains(this.FindText) ?? false) || (vm.ActionWithBalance.Action.Remark?.Remark.Contains(this.FindText) ?? false))];
+                tmp = [.. tmp.Where(vm => (vm.Shop?.Contains(this.FindText) ?? false) || (vm.Remark?.Contains(this.FindText) ?? false))];
             }
 
             this.DisplayedActionVMList = tmp;
 
             // 選択項目を表示項目に限定する
-            this.SelectedActionVMList = [.. this.SelectedActionVMList.Where(vm => this.DisplayedActionVMList.Contains(vm))];
+            this.ActionSelectorVM.SelectedItemList = [.. this.ActionSelectorVM.SelectedItemList.Where(vm => this.DisplayedActionVMList.Contains(vm))];
         }
 
         public override void Initialize(BusyService busyService, DbHandlerFactory dbHandlerFactory)
@@ -589,6 +551,11 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             this.mAppService = new(this.mDbHandlerFactory);
             this.mMainService = new(this.mDbHandlerFactory);
 
+            this.ActionSelectorVM.SetLoader(async () => this.Parent.DisplayedPeriodKind switch {
+                PeriodKind.Monthly => (await this.mMainService.LoadActionListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedMonth.Value)).Select(tmp => new ActionViewModel(tmp)),
+                PeriodKind.Selected => (await this.mMainService.LoadActionListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedPeriod)).Select(tmp => new ActionViewModel(tmp)),
+                _ => null
+            }, mode: SelectorMode.FirstOrDefault);
             this.SummarySelectorVM.SetLoader(async () => this.Parent.DisplayedPeriodKind switch {
                 PeriodKind.Monthly => await this.mMainService.LoadSummaryListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedMonth.Value),
                 PeriodKind.Selected => await this.mMainService.LoadSummaryListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedPeriod),
@@ -616,7 +583,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             using IDisposable disposable = this.mBusyService.Enter();
 
             // 指定がなければ、更新前の帳簿項目の選択を維持する
-            IEnumerable<ActionIdObj> tmpActionIdList = actionIdList ?? this.SelectedActionVMList.Select(tmp => tmp.ActionWithBalance.Action.ActionId);
+            IEnumerable<ActionIdObj> tmpActionIdList = actionIdList ?? this.ActionSelectorVM.SelectedKeys;
             // 指定がなければ、更新前のサマリーの選択を維持する
             BalanceKind? tmpBalanceKind = balanceKind ?? this.Parent.SelectedBalanceKind;
             CategoryIdObj tmpCategoryId = categoryId ?? this.Parent.SelectedCategoryId;
@@ -624,22 +591,12 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             Log.Vars(vars: new { tmpActionIdList, tmpBalanceKind, tmpCategoryId, tmpItemId });
 
             // 表示するデータを指定する
-            switch (this.Parent.DisplayedPeriodKind) {
-                case PeriodKind.Monthly: {
-                    var tmp1 = await this.mMainService.LoadActionListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedMonth.Value);
-                    this.ActionVMList = [.. tmp1.Select(tmp => new ActionViewModel(tmp))];
-                    break;
-                }
-                case PeriodKind.Selected: {
-                    var tmp1 = await this.mMainService.LoadActionListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedPeriod);
-                    this.ActionVMList = [.. tmp1.Select(tmp => new ActionViewModel(tmp))];
-                    break;
-                }
-            }
-            await this.SummarySelectorVM.LoadAsync((tmpBalanceKind, tmpCategoryId, tmpItemId));
-
-            // 帳簿項目を選択する(サマリーの選択はこの段階では無視して処理する)
-            this.SelectedActionVMList = [.. this.ActionVMList.Where(vm => tmpActionIdList.Contains(vm.ActionWithBalance.Action.ActionId))];
+            Task[] tasks = [
+                this.ActionSelectorVM.LoadAsync(actionIdList),
+                this.SummarySelectorVM.LoadAsync((tmpBalanceKind, tmpCategoryId, tmpItemId))
+            ];
+            await Task.WhenAll(tasks);
+            this.UpdateDisplayedActionVMList();
 
             if (isScroll) {
                 if (this.Parent.DisplayedPeriodKind == PeriodKind.Monthly &&
@@ -664,9 +621,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             using FuncLog funcLog = new();
 
             // 帳簿項目選択変更時
-            this.SelectedActionVMList.CollectionChanged += (sender, e) => {
-                using FuncLog funcLog = new(new { ActionIdList = this.SelectedActionVMList.Select(vm => vm.ActionWithBalance.Action.ActionId) }, methodName: nameof(this.SelectedActionVMList.CollectionChanged));
-
+            this.ActionSelectorVM.SelectedCollectionChanged += (sender, e) => {
                 this.RaisePropertyChanged(nameof(this.AverageValue));
                 this.RaisePropertyChanged(nameof(this.Count));
                 this.RaisePropertyChanged(nameof(this.SumValue));

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowGraphTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowGraphTabViewModel.cs
@@ -102,7 +102,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
 
             this.SeriesSelectorVM.SetLoader(async () => {
                 SeriesViewModelLoader loader = new(new(this.mDbHandlerFactory));
-                var tmpVMList = this.Tab switch {
+                IEnumerable<SeriesViewModel> tmpVMList = this.Tab switch {
                     Tabs.DailyGraphTab => this.Parent.DisplayedPeriodKind switch {
                         PeriodKind.Monthly => await loader.LoadDailySeriesViewModelListWithinMonthAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedMonth.Value),
                         PeriodKind.Selected => await loader.LoadDailySeriesViewModelListAsync(this.Parent.BookSelectorVM.SelectedKey, this.Parent.DisplayedPeriod),

--- a/HouseholdAccountBook/Views/Behaviors/BindSelectedItemsToDataGridBehavior.cs
+++ b/HouseholdAccountBook/Views/Behaviors/BindSelectedItemsToDataGridBehavior.cs
@@ -1,10 +1,10 @@
 ﻿using HouseholdAccountBook.ViewModels.Abstract;
 using Microsoft.Xaml.Behaviors;
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
-using System;
 
 namespace HouseholdAccountBook.Views.Behaviors
 {

--- a/HouseholdAccountBook/Views/Behaviors/BindSelectedItemsToDataGridBehavior.cs
+++ b/HouseholdAccountBook/Views/Behaviors/BindSelectedItemsToDataGridBehavior.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
+using System;
 
 namespace HouseholdAccountBook.Views.Behaviors
 {
@@ -104,10 +105,16 @@ namespace HouseholdAccountBook.Views.Behaviors
         /// <param name="e"></param>
         private static void SelectedItems_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            bool unsupportedFlag = false;
+
             if (e.OldItems != null) {
                 foreach (object oldItem in e.OldItems) {
                     if (oldItem is ISelectable oldV) {
                         oldV.SelectFlag = false;
+                    }
+                    else {
+                        unsupportedFlag = true;
+                        break;
                     }
                 }
             }
@@ -116,7 +123,15 @@ namespace HouseholdAccountBook.Views.Behaviors
                     if (newItem is ISelectable newV) {
                         newV.SelectFlag = true;
                     }
+                    else {
+                        unsupportedFlag = true;
+                        break;
+                    }
                 }
+            }
+
+            if (unsupportedFlag) {
+                throw new NotSupportedException($"{nameof(SelectedItems)} are not {nameof(ISelectable)}");
             }
         }
         #endregion

--- a/HouseholdAccountBook/Views/Windows/CsvComparisonWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/CsvComparisonWindow.xaml
@@ -141,7 +141,7 @@
                     <MouseBinding Gesture="LeftDoubleClick" Command="{Binding AddOrEditActionCommand}"/>
                 </DataGrid.InputBindings>
                 <i:Interaction.Behaviors>
-                    <behaviors:BindSelectedItemsToDataGridBehavior SelectedItems="{Binding SelectedCsvCompVMList, Mode=OneWay}"/>
+                    <behaviors:BindSelectedItemsToDataGridBehavior SelectedItems="{Binding CsvCompSelectorVM.SelectedItemList, Mode=OneWay}"/>
                 </i:Interaction.Behaviors>
                 <DataGrid.ItemContainerStyle>
                     <Style TargetType="DataGridRow">
@@ -199,12 +199,12 @@
                 <TextBlock Margin="5,0" VerticalAlignment="Center">
                     [<TextBlock Text="{x:Static properties:Resources.TextBlock_Whole}"/>]
                     <TextBlock Text="{x:Static properties:Resources.TextBlock_Checked}"/>: 
-                    <TextBlock Text="{Binding AllCheckedCount}"/> / <TextBlock Text="{Binding AllCount}"/><TextBlock Text="  "/>
+                    <TextBlock Text="{Binding AllCheckedCount}"/> / <TextBlock Text="{Binding CsvCompSelectorVM.Count}"/><TextBlock Text="  "/>
                     <TextBlock Text="{x:Static properties:Resources.TextBlock_Sum}"/>:
                     <TextBlock Text="{Binding AllSumValue, Converter={StaticResource IntToMoneyDisplayConverter}}"/><TextBlock Text="  "/>
                     [<TextBlock Text="{x:Static properties:Resources.TextBlock_Selection}"/>]
                     <TextBlock Text="{x:Static properties:Resources.TextBlock_Checked}"/>:
-                    <TextBlock Text="{Binding SelectedCheckedCount}"/> / <TextBlock Text="{Binding SelectedCount}"/><TextBlock Text="  "/>
+                    <TextBlock Text="{Binding SelectedCheckedCount}"/> / <TextBlock Text="{Binding CsvCompSelectorVM.SelectedCount}"/><TextBlock Text="  "/>
                     <TextBlock Text="{x:Static properties:Resources.TextBlock_Sum}"/>:
                     <TextBlock Text="{Binding SelectedSumValue, Converter={StaticResource IntToMoneyDisplayConverter}}"/>
                 </TextBlock>

--- a/HouseholdAccountBook/Views/Windows/MainWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/MainWindow.xaml
@@ -390,7 +390,7 @@
                             </Grid.RowDefinitions>
 
                             <DataGrid x:Name="_actionDataGrid" Grid.Row="0" SelectionMode="Extended"
-                                  ItemsSource="{Binding DisplayedActionVMList}" SelectedItem="{Binding SelectedActionVM}" IsReadOnly="True" SelectionUnit="FullRow"
+                                  ItemsSource="{Binding DisplayedActionVMList}" SelectedItem="{Binding ActionSelectorVM.SelectedItem}" IsReadOnly="True" SelectionUnit="FullRow"
                                   CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False" FrozenColumnCount="4"
                                   AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="True" CanUserSortColumns="True"
                                   HorizontalGridLinesBrush="#FFF0F0F0" VerticalGridLinesBrush="#FFF0F0F0" AlternatingRowBackground="#FFFFFFE0" FontSize="10.5" FontFamily="Meiryo">
@@ -411,7 +411,7 @@
                                     <MouseBinding Gesture="LeftDoubleClick" Command="{Binding EditCommand}"/>
                                 </DataGrid.InputBindings>
                                 <i:Interaction.Behaviors>
-                                    <behaviors:BindSelectedItemsToDataGridBehavior SelectedItems="{Binding SelectedActionVMList}"/>
+                                    <behaviors:BindSelectedItemsToDataGridBehavior SelectedItems="{Binding ActionSelectorVM.SelectedItemList}"/>
                                 </i:Interaction.Behaviors>
                                 <DataGrid.ItemContainerStyle>
                                     <Style TargetType="DataGridRow">

--- a/HouseholdAccountBook/Views/Windows/MainWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/MainWindow.xaml
@@ -390,7 +390,7 @@
                             </Grid.RowDefinitions>
 
                             <DataGrid x:Name="_actionDataGrid" Grid.Row="0" SelectionMode="Extended"
-                                  ItemsSource="{Binding DisplayedActionVMList}" SelectedItem="{Binding ActionSelectorVM.SelectedItem}" IsReadOnly="True" SelectionUnit="FullRow"
+                                  ItemsSource="{Binding FilteredActionVMList}" SelectedItem="{Binding ActionSelectorVM.SelectedItem}" IsReadOnly="True" SelectionUnit="FullRow"
                                   CanUserAddRows="False" CanUserDeleteRows="False" CanUserResizeRows="False" FrozenColumnCount="4"
                                   AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="True" CanUserSortColumns="True"
                                   HorizontalGridLinesBrush="#FFF0F0F0" VerticalGridLinesBrush="#FFF0F0F0" AlternatingRowBackground="#FFFFFFE0" FontSize="10.5" FontFamily="Meiryo">

--- a/HouseholdAccountBook/Views/Windows/MainWindow.xaml.cs
+++ b/HouseholdAccountBook/Views/Windows/MainWindow.xaml.cs
@@ -248,7 +248,7 @@ namespace HouseholdAccountBook.Views.Windows
                     this.mCCW.IsMatchChanged += (sender, e) => {
                         using FuncLog funcLog = new(methodName: nameof(this.mCCW.IsMatchChanged));
 
-                        ActionViewModel vm = this.WVM.BookTabVM.ActionVMList.FirstOrDefault(tmpVM => tmpVM.ActionWithBalance.Action.ActionId == e.Value1);
+                        ActionViewModel vm = this.WVM.BookTabVM.ActionSelectorVM.ItemList.FirstOrDefault(tmpVM => tmpVM.ActionWithBalance.Action.ActionId == e.Value1);
                         // UI上の表記だけを更新する
                         _ = (vm?.IsMatch = e.Value2);
                     };


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- #108 で、SelectorViewModel を適用したが、帳簿項目VMは適用対象外としていた

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- ログ出力対象の変数がdecimalのときに値が出力されないのを修正
- 帳簿項目一覧に、SelectorViewModelを適用するように変更
- 表示対象の帳簿項目一覧のフィルタ方法を変更
- SelectedItemListをSelectorViewModelに含めるように変更

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 操作時、金額がログ出力される(CSV比較など)
1. 帳簿項目が意図したとおりに表示される
   1. フィルタ/検索無効な場合
   2. フィルタ有効な場合
   3. 検索有効な場合
   4. フィルタ/検索ともに有効な場合

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #151

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
