### PR TITLE
#166 帳簿項目登録ウィンドウ、帳簿項目リスト登録ウィンドウで帳簿を変更しても項目リストが更新されない

### DIFF
--- a/HouseholdAccountBook/Models/AppServices/BusyService.cs
+++ b/HouseholdAccountBook/Models/AppServices/BusyService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HouseholdAccountBook.Infrastructure.Logger;
+using System;
 using System.ComponentModel;
 using System.Threading;
 
@@ -39,9 +40,12 @@ namespace HouseholdAccountBook.Models.AppServices
         public IDisposable Enter()
         {
             _ = Interlocked.Increment(ref this.mCount);
+            Log.Debug($"count:{this.mCount}");
             this.OnPropertyChanged(nameof(this.IsBusy));
+
             return new ActionOnDispose(() => {
                 _ = Interlocked.Decrement(ref this.mCount);
+                Log.Debug($"count:{this.mCount}");
                 this.OnPropertyChanged(nameof(this.IsBusy));
             });
         }

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -9,6 +9,10 @@
 - 全体
    - △ログ出力時の文字列化対象がstatic propertyの場合は対象から除外するように変更した - refs #161
    - ↑読込済のSelectorViewModelを再読込したときに選択状態がクリアされてしまうのを修正した - refs #162
+   - ↑DBからの読込等のときにカーソルが変化しないのを修正した - refs #164
+
+- ActionListRegistrationWindow, ActionRegistrationWindow
+   - ↑帳簿を変更したときに項目リストが更新されないのを修正した - refs #166
 
 ### 2026-05-16
 

--- a/HouseholdAccountBook/ViewModels/Abstract/WindowViewModelBase.cs
+++ b/HouseholdAccountBook/ViewModels/Abstract/WindowViewModelBase.cs
@@ -1,6 +1,4 @@
-﻿using HouseholdAccountBook.Infrastructure.DB.DbHandlers;
-using HouseholdAccountBook.Models.AppServices;
-using System;
+﻿using HouseholdAccountBook.Models.AppServices;
 using System.Windows;
 
 namespace HouseholdAccountBook.ViewModels.Abstract

--- a/HouseholdAccountBook/ViewModels/Windows/ActionListRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/ActionListRegistrationWindowViewModel.cs
@@ -288,7 +288,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
             using FuncLog funcLog = new();
 
             this.BookSelectorVM.SelectionChanged += (sender, e) => this.BookChanged?.Invoke(sender, e);
-            this.BookSelectorVM.Children.Add(this.CategorySelectorVM);
+            this.BookSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
 
             this.BalanceKindSelectorVM.SelectionChanged += (sender, e) => this.BalanceKindChanged?.Invoke(sender, e);
             this.BalanceKindSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);

--- a/HouseholdAccountBook/ViewModels/Windows/ActionRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/ActionRegistrationWindowViewModel.cs
@@ -343,11 +343,14 @@ namespace HouseholdAccountBook.ViewModels.Windows
             using FuncLog funcLog = new();
 
             this.BookSelectorVM.SelectionChanged += (sender, e) => this.BookChanged?.Invoke(sender, e);
-            this.BookSelectorVM.Children.Add(this.CategorySelectorVM);
+            this.BookSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
+
             this.BalanceKindSelectorVM.SelectionChanged += (sender, e) => this.BalanceKindChanged?.Invoke(sender, e);
             this.BalanceKindSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
+
             this.CategorySelectorVM.SelectionChanged += (sender, e) => this.CategoryChanged?.Invoke(sender, e);
             this.CategorySelectorVM.Children.Add(this.ItemSelectorVM);
+
             this.ItemSelectorVM.SelectionChanged += (sender, e) => this.ItemChanged?.Invoke(sender, e);
             this.ItemSelectorVM.Children.AddRange([this.ShopSelectorVM, this.RemarkSelectorVM]);
         }

--- a/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
@@ -339,10 +339,13 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
             this.FromBookSelectorVM.SelectionChanged += (sender, e) => this.FromBookChanged?.Invoke(sender, e);
             this.FromBookSelectorVM.Children.Add(this.ItemSelectorVM);
+
             this.ToBookSelectorVM.SelectionChanged += (sender, e) => this.ToBookChanged?.Invoke(sender, e);
             this.ToBookSelectorVM.Children.Add(this.ItemSelectorVM);
+
             this.CommissionKindSelectorVM.SelectionChanged += (sender, e) => this.CommissionKindChanged?.Invoke(sender, e);
             this.CommissionKindSelectorVM.Children.Add(this.ItemSelectorVM);
+
             this.ItemSelectorVM.SelectionChanged += (sender, e) => this.ItemChanged?.Invoke(sender, e);
             this.ItemSelectorVM.Children.Add(this.RemarkSelectorVM);
         }


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- 帳簿項目登録ウィンドウ、帳簿項目リスト登録ウィンドウで帳簿を変更しても項目リストが更新されない

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- 帳簿項目登録ウィンドウ、帳簿項目リスト登録ウィンドウで帳簿を変更したときに項目リストが更新されないのを修正

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 帳簿項目登録ウィンドウまたは帳簿項目リスト登録ウィンドウを開く
1. 帳簿リストの選択を変更する
1. 項目リストが帳簿の選択に応じて更新される

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #166
- refs #108

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
