### PR TITLE
#176 SQLite使用時の処理を高速化する1

### DIFF
--- a/HouseholdAccountBook/App.config
+++ b/HouseholdAccountBook/App.config
@@ -388,6 +388,12 @@
       <setting name="App_LatestVersionNotifyAtAppLaunched" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="App_SQLite_CacheSize_MB" serializeAs="String">
+        <value>64</value>
+      </setting>
+      <setting name="App_SQLite_MmapSize_MB" serializeAs="String">
+        <value>256</value>
+      </setting>
     </HouseholdAccountBook.Properties.Settings>
   </userSettings>
 </configuration>

--- a/HouseholdAccountBook/App.xaml
+++ b/HouseholdAccountBook/App.xaml
@@ -11,7 +11,7 @@
 
     <Application.Resources>
         <!-- コンバータ -->
-        <converters:BoolToEnumConverter x:Key="BoolToEnumConverter"/>
+        <converters:EnumToBoolConverter x:Key="EnumToBoolConverter"/>
         <converters:DateTimeToDayOfWeekConverter x:Key="DateTimeToDayOfWeekConverter"/>
         <converters:DateTimeToDisplayedMonthConverter x:Key="DateTimeToDisplayedMonthConverter"/>
         <converters:DateTimeToDisplayedYearConverter x:Key="DateTimeToDisplayedYearConverter"/>

--- a/HouseholdAccountBook/App.xaml.cs
+++ b/HouseholdAccountBook/App.xaml.cs
@@ -126,10 +126,13 @@ namespace HouseholdAccountBook
                 return;
             }
 
-            // DBバックアップマネージャーを初期化する
+            // SQLiteDbHandlerを初期化する
+            SQLiteDbHandler.Config = UserSettingService.Instance.SQLiteConfig;
+
+            // DBBackUpManagerを初期化する
             DbBackUpManager.Instance.DbHandlerFactory = dbHandlerFactory;
             DbBackUpManager.Instance.Config = UserSettingService.Instance.DbBackupConfig;
-            DbBackUpManager.Instance.NpgsqlBackupConfig = UserSettingService.Instance.PostgreSQLBackupConfig;
+            DbBackUpManager.Instance.NpgsqlConfig = UserSettingService.Instance.PostgreSQLBackupConfig;
             DbBackUpManager.Instance.BackUpCurrentAtMinimizing = UserSettingService.Instance.CurrentBackUpAtMinimizing;
 
             // DBのマイグレーションを実行する

--- a/HouseholdAccountBook/Infrastructure/DB/DbBackUpManager.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbBackUpManager.cs
@@ -103,7 +103,7 @@ namespace HouseholdAccountBook.Infrastructure.DB
         /// <summary>
         /// Npgsqlバックアップ設定
         /// </summary>
-        public NpgsqlDbHandler.BackupConfiguration NpgsqlBackupConfig { get; set; }
+        public NpgsqlDbHandler.BackupConfiguration NpgsqlConfig { get; set; }
 
         /// <summary>
         /// メインウィンドウを最小化したときにバックアップを行った時刻
@@ -237,13 +237,13 @@ namespace HouseholdAccountBook.Infrastructure.DB
         {
             using FuncLog funcLog = new(new { backupFilePath, format, notifyResult, waitForFinish });
 
-            if (this.NpgsqlBackupConfig.DumpExePath == string.Empty) { return false; }
+            if (this.NpgsqlConfig.DumpExePath == string.Empty) { return false; }
 
             int? errorCode = -1;
             await using (DbHandlerBase dbHandler = await this.DbHandlerFactory.CreateAsync()) {
                 if (dbHandler is NpgsqlDbHandler npgsqlDbHandler) {
                     errorCode = notifyResult
-                        ? await npgsqlDbHandler.ExecuteDump(backupFilePath, this.NpgsqlBackupConfig, format,
+                        ? await npgsqlDbHandler.ExecuteDump(backupFilePath, this.NpgsqlConfig, format,
                             exitCode => {
                                 // ダンプ結果を通知する
                                 if (exitCode == 0) {
@@ -253,7 +253,7 @@ namespace HouseholdAccountBook.Infrastructure.DB
                                     NotificationService.NotifyFailedToBackup();
                                 }
                             }, waitForFinish)
-                        : await npgsqlDbHandler.ExecuteDump(backupFilePath, this.NpgsqlBackupConfig, format, null, waitForFinish);
+                        : await npgsqlDbHandler.ExecuteDump(backupFilePath, this.NpgsqlConfig, format, null, waitForFinish);
                 }
             }
             return errorCode == null ? null : (errorCode == 0);
@@ -268,12 +268,12 @@ namespace HouseholdAccountBook.Infrastructure.DB
         {
             using FuncLog funcLog = new(new { backupFilePath });
 
-            if (this.NpgsqlBackupConfig.RestoreExePath == string.Empty) { return false; }
+            if (this.NpgsqlConfig.RestoreExePath == string.Empty) { return false; }
 
             int errorCode = -1;
             await using (DbHandlerBase dbHandler = await this.DbHandlerFactory.CreateAsync()) {
                 if (dbHandler is NpgsqlDbHandler npgsqlDbHandler) {
-                    errorCode = await npgsqlDbHandler.ExecuteRestore(backupFilePath, this.NpgsqlBackupConfig);
+                    errorCode = await npgsqlDbHandler.ExecuteRestore(backupFilePath, this.NpgsqlConfig);
                 }
             }
             return errorCode == 0;

--- a/HouseholdAccountBook/Infrastructure/DB/DbHandlers/Abstract/DbHandlerBase.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbHandlers/Abstract/DbHandlerBase.cs
@@ -84,7 +84,7 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbHandlers.Abstract
         /// <param name="timeoutMs">タイムアウト時間(ms)。0以下の場合は無制限</param>
         /// <returns>接続結果</returns>
         /// <exception cref="TimeoutException">接続タイムアウトが発生した場合</exception>
-        public async Task<bool> OpenAsync(int timeoutMs = 0)
+        public virtual async Task<bool> OpenAsync(int timeoutMs = 0)
         {
             using FuncLog funcLog = new(new { timeoutMs }, Log.LogLevel.Trace);
 
@@ -117,17 +117,17 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbHandlers.Abstract
         /// <summary>
         /// [非同期]接続を終了する
         /// </summary>
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
             using FuncLog funcLog = new(new { }, Log.LogLevel.Trace);
-
-            GC.SuppressFinalize(this);
 
             if (this.mConnection != null) {
                 await this.mConnection.CloseAsync();
                 await this.mConnection.DisposeAsync();
             }
             this.mConnection = null;
+
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/HouseholdAccountBook/Infrastructure/DB/DbHandlers/SQLiteDbHandler.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbHandlers/SQLiteDbHandler.cs
@@ -2,6 +2,7 @@
 using HouseholdAccountBook.Infrastructure.DB.DbHandlers.Abstract;
 using HouseholdAccountBook.Infrastructure.Logger;
 using Microsoft.Data.Sqlite;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -12,6 +13,22 @@ namespace HouseholdAccountBook.Models.DbHandlers
     /// </summary>
     public partial class SQLiteDbHandler : DbHandlerBase
     {
+        /// <summary>
+        /// pragma設定
+        /// </summary>
+        public class PragmaConfiguration
+        {
+            /// <summary>
+            /// キャッシュサイズの最大値[MB]
+            /// </summary>
+            public uint CacheSize { get; set; } = 64;
+
+            /// <summary>
+            /// メモリマップドI/Oサイズの最大値[MB]
+            /// </summary>
+            public uint MmapSize { get; set; } = 256;
+        }
+
         #region フィールド
         /// <summary>
         /// 接続文字列
@@ -24,6 +41,10 @@ namespace HouseholdAccountBook.Models.DbHandlers
         /// DBファイルパス
         /// </summary>
         public string DbFilePath => (this.mConnectInfoBase as ConnectInfo).FilePath;
+        /// <summary>
+        /// gragma設定
+        /// </summary>
+        public static PragmaConfiguration Config { get; set; } = new();
         #endregion
 
         /// <summary>
@@ -46,6 +67,52 @@ namespace HouseholdAccountBook.Models.DbHandlers
             if (!File.Exists(filePath)) {
                 this.CanOpen = false;
             }
+        }
+
+        public override async Task<bool> OpenAsync(int timeoutMs = 0)
+        {
+            using FuncLog funcLog = new(new { timeoutMs }, Log.LogLevel.Trace);
+
+            bool opened = await base.OpenAsync(timeoutMs);
+            if (opened) {
+                try {
+                    // WALモード：Write-Ahead Logging による同時実行性の向上
+                    _ = await this.ExecuteAsync("PRAGMA journal_mode = WAL;");
+
+                    // キャッシュサイズ[KB]を設定
+                    _ = await this.ExecuteAsync($"PRAGMA cache_size = -{Config.CacheSize * 1024};");
+
+                    // メモリマッピング[bytes]を設定
+                    _ = await this.ExecuteAsync($"PRAGMA mmap_size = {Config.MmapSize * 1024 * 1024};");
+
+                    // 同期レベルを落とす（NORMAL: ディスクフラッシュを最小化）
+                    _ = await this.ExecuteAsync("PRAGMA synchronous = NORMAL;");
+
+                    // テンポラリストレージを使用
+                    _ = await this.ExecuteAsync("PRAGMA temp_store = MEMORY;");
+                }
+                catch {
+                    // 最適化設定が失敗してもDBは使用可能にする
+                }
+            }
+
+            return opened;
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            using FuncLog funcLog = new(new { }, Log.LogLevel.Trace);
+
+            if (this.mConnection != null) {
+                try {
+                    // クエリ最適化レベルを上げる
+                    _ = await this.ExecuteAsync("PRAGMA optimize;");
+                }
+                catch { }
+            }
+            await base.DisposeAsync();
+
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/HouseholdAccountBook/Infrastructure/Logger/WindowLog.cs
+++ b/HouseholdAccountBook/Infrastructure/Logger/WindowLog.cs
@@ -106,9 +106,9 @@ namespace HouseholdAccountBook.Infrastructure.Logger
             GC.SuppressFinalize(this);
         }
 
-        private void SystemEvents_DisplaySettingsChanging(object sender, EventArgs e) => this.Log("DisplaySettingsChanging", true);
+        private void SystemEvents_DisplaySettingsChanging(object sender, EventArgs e) => this.Log(nameof(SystemEvents.DisplaySettingsChanging), true);
 
-        private void SystemEvents_DisplaySettingsChanged(object sender, EventArgs e) => this.Log("DisplaySettingsChanged", true);
+        private void SystemEvents_DisplaySettingsChanged(object sender, EventArgs e) => this.Log(nameof(SystemEvents.DisplaySettingsChanged), true);
 
         /// <summary>
         /// ウィンドウの状態、位置をログファイルに保存する

--- a/HouseholdAccountBook/Models/AppServices/UserSettingService.cs
+++ b/HouseholdAccountBook/Models/AppServices/UserSettingService.cs
@@ -630,6 +630,21 @@ namespace HouseholdAccountBook.Models.AppServices
         }
 
         /// <summary>
+        /// SQLite pragma設定情報
+        /// </summary>
+        public SQLiteDbHandler.PragmaConfiguration SQLiteConfig {
+            get => new() {
+                CacheSize = this.mSettings.App_SQLite_CacheSize_MB,
+                MmapSize = this.mSettings.App_SQLite_MmapSize_MB
+            };
+            set {
+                this.mSettings.App_SQLite_CacheSize_MB = value.CacheSize;
+                this.mSettings.App_SQLite_MmapSize_MB = value.MmapSize;
+                this.mSettings.Save();
+            }
+        }
+
+        /// <summary>
         /// Access接続情報
         /// </summary>
         public OleDbHandler.ConnectInfo AccessConnectInfo {
@@ -710,7 +725,7 @@ namespace HouseholdAccountBook.Models.AppServices
                 IntervalMinAtMinimizing = this.mSettings.App_BackUpIntervalMinAtMinimizing,
                 NotifyAtMinimizing = this.mSettings.App_BackUpNotifyAtMinimizing,
                 ExecuteAtClosing = this.mSettings.App_BackUpFlagAtClosing,
-                Condition = (BackUpCondition)this.mSettings.App_BackUpCondition
+                Condition = EnumUtil.SafeCastEnum(this.mSettings.App_BackUpCondition, BackUpCondition.Always)
             };
             set {
                 this.mSettings.App_BackUpNum = value.Amount;
@@ -731,7 +746,7 @@ namespace HouseholdAccountBook.Models.AppServices
             get => new() {
                 DumpExePath = this.mSettings.App_Postgres_DumpExePath,
                 RestoreExePath = this.mSettings.App_Postgres_RestoreExePath,
-                PasswordInput = (PostgresPasswordInput)this.mSettings.App_Postgres_Password_Input
+                PasswordInput = EnumUtil.SafeCastEnum(this.mSettings.App_Postgres_Password_Input, PostgresPasswordInput.InputWindow)
             };
             set {
                 this.mSettings.App_Postgres_DumpExePath = value.DumpExePath;

--- a/HouseholdAccountBook/Properties/Resources.en-001.resx
+++ b/HouseholdAccountBook/Properties/Resources.en-001.resx
@@ -1135,4 +1135,10 @@ list</value>
   <data name="Menu_Debug_ThrowUnhandledException" xml:space="preserve">
     <value>Throw unhandled exception (_H)</value>
   </data>
+  <data name="TextBlock_SQLite_CacheSize" xml:space="preserve">
+    <value>Cache size</value>
+  </data>
+  <data name="TextBlock_SQLite_MmapSize" xml:space="preserve">
+    <value>Memory-mapped I/O size</value>
+  </data>
 </root>

--- a/HouseholdAccountBook/Properties/Resources.ja.resx
+++ b/HouseholdAccountBook/Properties/Resources.ja.resx
@@ -1135,4 +1135,10 @@
   <data name="Menu_Debug_ThrowUnhandledException" xml:space="preserve">
     <value>未処理例外スロー(_H)</value>
   </data>
+  <data name="TextBlock_SQLite_CacheSize" xml:space="preserve">
+    <value>キャッシュサイズ</value>
+  </data>
+  <data name="TextBlock_SQLite_MmapSize" xml:space="preserve">
+    <value>メモリマップドI/Oサイズ</value>
+  </data>
 </root>

--- a/HouseholdAccountBook/Properties/Resources.resx
+++ b/HouseholdAccountBook/Properties/Resources.resx
@@ -1135,4 +1135,10 @@
   <data name="Menu_Debug_ThrowUnhandledException" xml:space="preserve">
     <value>未処理例外スロー(_H)</value>
   </data>
+  <data name="TextBlock_SQLite_CacheSize" xml:space="preserve">
+    <value>キャッシュサイズ</value>
+  </data>
+  <data name="TextBlock_SQLite_MmapSize" xml:space="preserve">
+    <value>メモリマップドI/Oサイズ</value>
+  </data>
 </root>

--- a/HouseholdAccountBook/Properties/Settings.Designer.cs
+++ b/HouseholdAccountBook/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace HouseholdAccountBook.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.5.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -1124,6 +1124,30 @@ namespace HouseholdAccountBook.Properties {
             }
             set {
                 this["App_LatestVersionNotifyAtAppLaunched"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("64")]
+        public uint App_SQLite_CacheSize_MB {
+            get {
+                return ((uint)(this["App_SQLite_CacheSize_MB"]));
+            }
+            set {
+                this["App_SQLite_CacheSize_MB"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("256")]
+        public uint App_SQLite_MmapSize_MB {
+            get {
+                return ((uint)(this["App_SQLite_MmapSize_MB"]));
+            }
+            set {
+                this["App_SQLite_MmapSize_MB"] = value;
             }
         }
     }

--- a/HouseholdAccountBook/Properties/Settings.settings
+++ b/HouseholdAccountBook/Properties/Settings.settings
@@ -278,5 +278,11 @@
     <Setting Name="App_LatestVersionNotifyAtAppLaunched" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="App_SQLite_CacheSize_MB" Type="System.UInt32" Scope="User">
+      <Value Profile="(Default)">64</Value>
+    </Setting>
+    <Setting Name="App_SQLite_MmapSize_MB" Type="System.UInt32" Scope="User">
+      <Value Profile="(Default)">256</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -8,6 +8,11 @@
 
 - 全体
    - ↑IDispose を継承したクラスのFinalizerでDisposeを呼び出していたのを修正した - refs #177
+   - △SQLite接続時/切断時に、pragma journal_mode/cache_size/mmap_size/synchronous/temp_store/optimize を指定するように変更した - refs #176
+
+- SettingWindow
+  - +SQLiteの cache_size/mmap_size の指定を追加した - refs #176
+  - △接続していないDBの接続設定を変更不可に変更した - refs #176
 
 ### 2026-05-23
 

--- a/HouseholdAccountBook/ViewModels/Loaders/SeriesViewModelLoader.cs
+++ b/HouseholdAccountBook/ViewModels/Loaders/SeriesViewModelLoader.cs
@@ -41,8 +41,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
         /// 期間内日別系列VMリストを取得する(日別グラフタブ)
         /// </summary>
         /// <param name="bookId">帳簿ID</param>
-        /// <param name="startTime">開始時刻</param>
-        /// <param name="endTime">終了時刻</param>
+        /// <param name="period">期間</param>
         /// <returns>日別系列VMリスト</returns>
         public async Task<IEnumerable<SeriesViewModel>> LoadDailySeriesViewModelListAsync(BookIdObj bookId, PeriodObj<DateOnly> period)
         {

--- a/HouseholdAccountBook/ViewModels/Settings/SQLiteSettingViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Settings/SQLiteSettingViewModel.cs
@@ -19,6 +19,20 @@ namespace HouseholdAccountBook.ViewModels.Settings
             get;
             set => this.SetProperty(ref field, value);
         }
+        /// <summary>
+        /// 入力されたキャッシュサイズ[MB]
+        /// </summary>
+        public uint? InputedCacheSize {
+            get;
+            set => this.SetProperty(ref field, value);
+        }
+        /// <summary>
+        /// 入力されたメモリマップドI/Oサイズ[MB]
+        /// </summary>
+        public uint? InputedMmapSize {
+            get;
+            set => this.SetProperty(ref field, value);
+        }
 
         /// <summary>
         /// 設定を読み込む
@@ -27,6 +41,9 @@ namespace HouseholdAccountBook.ViewModels.Settings
         {
             SQLiteDbHandler.ConnectInfo connectInfo = UserSettingService.Instance.SQLiteConnectInfo;
             this.InputedDBFilePath = PathUtil.GetSmartPath(App.GetCurrentDir(), connectInfo.FilePath);
+            SQLiteDbHandler.PragmaConfiguration config = UserSettingService.Instance.SQLiteConfig;
+            this.InputedCacheSize = config.CacheSize;
+            this.InputedMmapSize = config.MmapSize;
         }
 
         /// <summary>
@@ -49,7 +66,7 @@ namespace HouseholdAccountBook.ViewModels.Settings
                     }
                 }
             }
-            // ファイルが存在する場合、設定を保存する
+            // ファイルが存在する場合、接続設定を保存する
             if (exists) {
                 SQLiteDbHandler.ConnectInfo connectInfo = new() {
                     FilePath = Path.GetFullPath(sqliteFilePath, App.GetCurrentDir())
@@ -58,6 +75,12 @@ namespace HouseholdAccountBook.ViewModels.Settings
                 result = true;
             }
 
+            SQLiteDbHandler.PragmaConfiguration config = new() {
+                CacheSize = this.InputedCacheSize.Value,
+                MmapSize = this.InputedMmapSize.Value
+            };
+            UserSettingService.Instance.SQLiteConfig = config;
+
             return result;
         }
 
@@ -65,6 +88,6 @@ namespace HouseholdAccountBook.ViewModels.Settings
         /// 設定を保存可能か
         /// </summary>
         /// <returns>設定の保存可否</returns>
-        public bool CanSave() => !string.IsNullOrWhiteSpace(this.InputedDBFilePath);
+        public bool CanSave() => !string.IsNullOrWhiteSpace(this.InputedDBFilePath) && this.InputedCacheSize.HasValue && this.InputedMmapSize.HasValue;
     }
 }

--- a/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
@@ -607,7 +607,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public ICommand ImportCustomFileCommand => field ??= new AsyncRelayCommand(
             this.ImportCustomFileCommand_ExecuteAsync, this,
-            () => this.IsPostgreSQL && !string.IsNullOrEmpty(DbBackUpManager.Instance.NpgsqlBackupConfig?.RestoreExePath) && !this.IsChildrenWindowOpened(),
+            () => this.IsPostgreSQL && !string.IsNullOrEmpty(DbBackUpManager.Instance.NpgsqlConfig?.RestoreExePath) && !this.IsChildrenWindowOpened(),
             this.mBusyService);
         /// <summary>
         /// カスタムファイル -> PostgreSQL インポートコマンド処理
@@ -718,7 +718,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public ICommand ExportCustomFileCommand => field ??= new AsyncRelayCommand(
             this.ExportCustomFileCommand_ExecuteAsync, this,
-            () => this.IsPostgreSQL && !string.IsNullOrEmpty(DbBackUpManager.Instance.NpgsqlBackupConfig?.DumpExePath) && !this.IsChildrenWindowOpened(),
+            () => this.IsPostgreSQL && !string.IsNullOrEmpty(DbBackUpManager.Instance.NpgsqlConfig?.DumpExePath) && !this.IsChildrenWindowOpened(),
             this.mBusyService);
         /// <summary>
         /// カスタムファイルエクスポートコマンド処理
@@ -750,7 +750,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public ICommand ExportSQLFileCommand => field ??= new AsyncRelayCommand(
             this.ExportSQLFileCommand_ExecuteAsync, this,
-            () => this.IsPostgreSQL && !string.IsNullOrEmpty(DbBackUpManager.Instance.NpgsqlBackupConfig?.DumpExePath) && !this.IsChildrenWindowOpened(),
+            () => this.IsPostgreSQL && !string.IsNullOrEmpty(DbBackUpManager.Instance.NpgsqlConfig?.DumpExePath) && !this.IsChildrenWindowOpened(),
             this.mBusyService);
         /// <summary>
         /// SQLファイルエクスポートコマンド処理

--- a/HouseholdAccountBook/ViewModels/WindowsParts/SettingsWindowDbTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/SettingsWindowDbTabViewModel.cs
@@ -3,6 +3,7 @@ using HouseholdAccountBook.Infrastructure.Logger;
 using HouseholdAccountBook.Infrastructure.Utilities;
 using HouseholdAccountBook.Infrastructure.Utilities.Args.RequestEventArgs;
 using HouseholdAccountBook.Models.AppServices;
+using HouseholdAccountBook.Models.DbHandlers;
 using HouseholdAccountBook.ViewModels.Abstract;
 using HouseholdAccountBook.ViewModels.Settings;
 using System;
@@ -271,6 +272,8 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
 
             // PostgreSQL
             _ = this.PostgreSQLDBSettingVM.Save(null);
+            // SQLite
+            _ = this.SQLiteSettingVM.Save();
             // Access(記帳風月)
             _ = this.AccessSettingVM.SaveForKichoFugetsu();
 
@@ -285,10 +288,12 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                 Condition = this.SelectedBackUpCondition
             };
 
+            // SQLiteDbHandlerへ設定を反映する
+            SQLiteDbHandler.Config = UserSettingService.Instance.SQLiteConfig;
+
             // DbBackUpManagerへ設定を反映する
             DbBackUpManager.Instance.Config = UserSettingService.Instance.DbBackupConfig;
-
-            DbBackUpManager.Instance.NpgsqlBackupConfig = UserSettingService.Instance.PostgreSQLBackupConfig;
+            DbBackUpManager.Instance.NpgsqlConfig = UserSettingService.Instance.PostgreSQLBackupConfig;
         }
     }
 }

--- a/HouseholdAccountBook/Views/Converters/EnumToBoolConverter.cs
+++ b/HouseholdAccountBook/Views/Converters/EnumToBoolConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Data;
 
 namespace HouseholdAccountBook.Views.Converters
 {
-    public class BoolToEnumConverter : IValueConverter
+    public class EnumToBoolConverter : IValueConverter
     {
         /// <summary>
         /// Enum -> Bool変換

--- a/HouseholdAccountBook/Views/Windows/PeriodSelectionWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/PeriodSelectionWindow.xaml
@@ -34,11 +34,11 @@
             <GroupBox Grid.Row="0">
                 <GroupBox.Header>
                     <RadioButton Content="{x:Static properties:Resources.GroupHeader_MonthSelection}"
-                                 IsChecked="{Binding SelectedPeriodKind, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=Monthly}"
+                                 IsChecked="{Binding SelectedPeriodKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Monthly}"
                                  GroupName="PeriodKind"/>
                 </GroupBox.Header>
 
-                <Grid IsEnabled="{Binding SelectedPeriodKind, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=Monthly}">
+                <Grid IsEnabled="{Binding SelectedPeriodKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Monthly}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
@@ -54,11 +54,11 @@
             <GroupBox Grid.Row="1">
                 <GroupBox.Header>
                     <RadioButton Content="{x:Static properties:Resources.GroupHeader_TermSelection}" 
-                                 IsChecked="{Binding SelectedPeriodKind, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=Selected}"
+                                 IsChecked="{Binding SelectedPeriodKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Selected}"
                                  GroupName="PeriodKind"/>
                 </GroupBox.Header>
 
-                <Grid IsEnabled="{Binding SelectedPeriodKind, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=Selected}">
+                <Grid IsEnabled="{Binding SelectedPeriodKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Selected}">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>

--- a/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml
@@ -536,31 +536,43 @@
                                     </Grid.RowDefinitions>
 
                                     <!-- SQLite -->
-                                    <GroupBox Grid.Row="0" Grid.Column="0">
+                                    <GroupBox Grid.Row="0" Grid.Column="0" IsEnabled="{Binding SelectedDBKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=SQLite}">
                                         <GroupBox.Header>
                                             <RadioButton Content="{x:Static properties:Resources.GroupHeader_SQLite}" 
-                                                         IsChecked="{Binding SelectedDBKind, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=SQLite}"
+                                                         IsChecked="{Binding SelectedDBKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=SQLite}"
                                                          GroupName="DBkindGroup" IsEnabled="False"/>
                                         </GroupBox.Header>
                                         <Grid DataContext="{Binding SQLiteSettingVM}">
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
                                             </Grid.RowDefinitions>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto" SharedSizeGroup="Header"/>
+                                                <ColumnDefinition Width="100" SharedSizeGroup="Number"/>
                                                 <ColumnDefinition Width="*"/>
                                                 <ColumnDefinition Width="30" SharedSizeGroup="Button"/>
                                             </Grid.ColumnDefinitions>
 
+                                            <!-- DBファイル名 -->
                                             <TextBlock Grid.Row="0" Grid.Column="0" Text="{x:Static properties:Resources.TextBlock_SQLite_DBFilePath}" Margin="5" VerticalAlignment="Center"/>
-                                            <TextBox Grid.Row="0" Grid.Column="1" Margin="1" Text="{Binding InputedDBFilePath}" IsReadOnly="True"/>
+                                            <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="1" Text="{Binding InputedDBFilePath}" IsReadOnly="True"/>
+                                            <!-- キャッシュサイズ -->
+                                            <TextBlock Grid.Row="1" Grid.Column="0" Text="{x:Static properties:Resources.TextBlock_SQLite_CacheSize}" Margin="5" VerticalAlignment="Center"/>
+                                            <controls:NumericUpDown Grid.Row="1" Grid.Column="1" Margin="5" MinValue="0" MaxValue="1024" Value="{Binding InputedCacheSize}"/>
+                                            <TextBlock Grid.Row="1" Grid.Column="2" Text="MB" Margin="5" VerticalAlignment="Center"/>
+                                            <!-- メモリマップドI/Oサイズ -->
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="{x:Static properties:Resources.TextBlock_SQLite_MmapSize}" Margin="5" VerticalAlignment="Center"/>
+                                            <controls:NumericUpDown Grid.Row="2" Grid.Column="1" Margin="5" MinValue="0" MaxValue="1024" Value="{Binding InputedMmapSize}"/>
+                                            <TextBlock Grid.Row="2" Grid.Column="2" Text="MB" Margin="5" VerticalAlignment="Center"/>
                                         </Grid>
                                     </GroupBox>
                                     <!-- PostgreSQL -->
-                                    <GroupBox Grid.Row="1" Grid.Column="0">
+                                    <GroupBox Grid.Row="1" Grid.Column="0" IsEnabled="{Binding SelectedDBKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=PostgreSQL}">
                                         <GroupBox.Header>
                                             <RadioButton Content="{x:Static properties:Resources.GroupHeader_PostgreSQL}" 
-                                                         IsChecked="{Binding SelectedDBKind, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=PostgreSQL}"
+                                                         IsChecked="{Binding SelectedDBKind, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=PostgreSQL}"
                                                          GroupName="DBKindGroup" IsEnabled="False"/>
                                         </GroupBox.Header>
                                         <Grid DataContext="{Binding PostgreSQLDBSettingVM}">
@@ -589,10 +601,10 @@
                                             <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" Text="{x:Static properties:Resources.TextBlock_Password}"/>
                                             <RadioButton Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" GroupName="pgpassword_input" Margin="5" 
                                                          Content="{x:Static properties:Resources.RadioButton_Password_ShowInputWindow}"
-                                                         IsChecked="{Binding SelectedPasswordInput, Converter={StaticResource BoolToEnumConverter}, Mode=TwoWay, ConverterParameter=InputWindow}"/>
+                                                         IsChecked="{Binding SelectedPasswordInput, Converter={StaticResource EnumToBoolConverter}, Mode=TwoWay, ConverterParameter=InputWindow}"/>
                                             <RadioButton Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" GroupName="pgpassword_pgpass" Margin="5" 
                                                          Content="{x:Static properties:Resources.RadioButton_Password_SpecifyPgpassConf}"
-                                                         IsChecked="{Binding SelectedPasswordInput, Converter={StaticResource BoolToEnumConverter}, Mode=TwoWay, ConverterParameter=PgPassConf}"/>
+                                                         IsChecked="{Binding SelectedPasswordInput, Converter={StaticResource EnumToBoolConverter}, Mode=TwoWay, ConverterParameter=PgPassConf}"/>
                                         </Grid>
                                     </GroupBox>
                                     <!-- Microsoft Access -->
@@ -668,10 +680,10 @@
                                     <TextBlock Grid.Row="4" Grid.Column="0" Margin="5" VerticalAlignment="Center"
                                                Text="{x:Static properties:Resources.TextBlock_BackUpCondition}"/>
                                     <RadioButton Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" Content="{x:Static properties:Resources.RadioButton_BackUpCondition_Always}" 
-                                                 IsChecked="{Binding SelectedBackUpCondition, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=Always}"
+                                                 IsChecked="{Binding SelectedBackUpCondition, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Always}"
                                                  GroupName="BackupCondition"/>
                                     <RadioButton Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" Content="{x:Static properties:Resources.RadioButton_BackUpCondition_Updated}" 
-                                                 IsChecked="{Binding SelectedBackUpCondition, Converter={StaticResource BoolToEnumConverter}, ConverterParameter=Updated}"
+                                                 IsChecked="{Binding SelectedBackUpCondition, Converter={StaticResource EnumToBoolConverter}, ConverterParameter=Updated}"
                                                  GroupName="BackupCondition"/>
                                     <!-- 通知 -->
                                     <TextBlock Grid.Row="6" Grid.Column="0" Margin="5" Text="{x:Static properties:Resources.TextBlock_Notifications}"/>


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- SQLiteの使用時、PostgreSQL使用時に比べてある程度処理が遅いのは性能上仕方がないが、なるべく高速化できる要素はないか、検討したい

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- SQLite接続時/切断時に、pragma journal_mode/cache_size/mmap_size/synchronous/temp_store/optimize を指定するように変更
- 設定にSQLiteの cache_size/mmap_size の指定を追加
- 設定で接続していないDBの接続設定を変更不可に変更

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 日別グラフの表示時間を比較
   - 変更前は6[s]程度、 変更後は3[s]程度となった

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #176

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- 遅くなっている原因としては、DBのインデックス設計にもあるため、別途修正を検討
   - その場合はマイグレーションが必要

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
