### PR TITLE
#214 帳簿ごとに表示スケールを設定可能にする

### DIFF
--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/ActionCompInfoDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/ActionCompInfoDao.cs
@@ -28,11 +28,16 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDao.Compositions
             using FuncLog funcLog = new(new { bookId, date, value }, Log.LogLevel.Trace);
 
             IEnumerable<ActionCompInfoDto> dtoList = await this.mDbHandler.QueryAsync<ActionCompInfoDto>(@"
-SELECT A.action_id, A.act_time, I.item_id, I.item_name, A.act_value / POWER(10, MA.scale) AS act_main_value, A.shop_name, A.remark, A.is_match, A.group_id
+SELECT A.action_id, A.act_time, I.item_id, I.item_name, A.asset_id,
+       (A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate AS main_act_value, BA.asset_id AS act_asset_id,
+       (A.act_value / POWER(10, AA.scale)) AS org_main_act_value, AA.asset_id AS org_asset_id,
+       A.shop_name, A.remark, A.is_match, A.group_id
 FROM hst_action A
 INNER JOIN mst_item I ON I.item_id = A.item_id AND I.del_flg = 0
-INNER JOIN mst_asset MA ON MA.asset_id = @DefaultAssetId AND MA.del_flg = 0
-WHERE @StartDate <= act_time AND act_time < @EndDate AND A.act_value = -@Value * POWER(10, MA.scale) AND book_id = @BookId AND A.del_flg = 0;",
+INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0
+INNER JOIN mst_asset BA ON BA.asset_id = COALESCE(B.asset_id, @DefaultAssetId) AND BA.del_flg = 0 -- 表示するアセット(帳簿に紐づくアセット)
+INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
+WHERE @StartDate <= act_time AND act_time < @EndDate AND A.act_value = -@Value * POWER(10, AA.scale) AND B.book_id = @BookId AND A.del_flg = 0;",
 new { DefaultAssetId = defaultAssetId, StartDate = date, EndDate = date.AddDays(1), Value = value, BookId = bookId });
 
             return dtoList;

--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/ActionInfoDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/ActionInfoDao.cs
@@ -16,6 +16,63 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDao.Compositions
     public class ActionInfoDao(DbHandlerBase dbHandler) : TableDaoBase(dbHandler)
     {
         /// <summary>
+        /// <see cref="HstActionDto.ActionId"/> に基づいて、<see cref="ActionInfoDto"/> を取得する
+        /// </summary>
+        /// <param name="actionId">帳簿項目ID</param>
+        /// <param name="defaultAssetId">デフォルトアセットID</param>
+        /// <returns>取得したレコード</returns>
+        public async Task<ActionInfoDto> FindByActionIdAsync(int actionId, int defaultAssetId)
+        {
+            using FuncLog funcLog = new(new { actionId, defaultAssetId }, Log.LogLevel.Trace);
+
+            ActionInfoDto dto = await this.mDbHandler.QuerySingleAsync<ActionInfoDto>(@"
+SELECT A.action_id, A.act_time, B.book_id, C.category_id, I.item_id, B.book_name, C.category_name, I.item_name, A.asset_id,
+       (A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base_rate AS main_act_value, DA.asset_id AS act_asset_id,
+       (A.act_value / POWER(10, AA.scale)) AS org_main_act_value, AA.asset_id AS org_act_asset_id,
+       A.shop_name, A.group_id, A.remark, A.is_match
+FROM hst_action A
+INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0 
+INNER JOIN mst_item I ON I.item_id = A.item_id AND I.move_flg = 0 AND I.del_flg = 0 
+INNER JOIN rel_book_item RBI ON RBI.item_id = I.item_id AND RBI.book_id = A.book_id AND RBI.del_flg = 0
+INNER JOIN mst_category C ON I.category_id = C.category_id AND C.del_flg = 0
+INNER JOIN mst_asset DA ON DA.asset_id = @DefaultAssetId AND DA.del_flg = 0 -- デフォルトアセット(不使用)
+INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
+WHERE A.del_flg = 0 AND A.action_id = @ActionId;
+",
+new { ActionId = actionId, DefaultAssetId = defaultAssetId });
+
+            return dto;
+        }
+        /// <summary>
+        /// <see cref="HstActionDto.GroupId"/> に基づいて、<see cref="ActionInfoDto"/> を取得する
+        /// </summary>
+        /// <param name="groupId">グループID</param>
+        /// <param name="defaultAssetId">デフォルトアセットID</param>
+        /// <returns>取得したレコードリスト</returns>
+        public async Task<IEnumerable<ActionInfoDto>> FindByGroupIdAsync(int groupId, int defaultAssetId)
+        {
+            using FuncLog funcLog = new(new { groupId, defaultAssetId }, Log.LogLevel.Trace);
+
+            IEnumerable<ActionInfoDto> dtoList = await this.mDbHandler.QueryAsync<ActionInfoDto>(@"
+SELECT A.action_id, A.act_time, B.book_id, C.category_id, I.item_id, B.book_name, C.category_name, I.item_name, A.asset_id,
+       (A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base_rate AS main_act_value, DA.asset_id AS act_asset_id,
+       (A.act_value / POWER(10, AA.scale)) AS org_main_act_value, AA.asset_id AS org_act_asset_id,
+       A.shop_name, A.group_id, A.remark, A.is_match
+FROM hst_action A
+INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0 
+INNER JOIN mst_item I ON I.item_id = A.item_id AND I.move_flg = 0 AND I.del_flg = 0 
+INNER JOIN rel_book_item RBI ON RBI.item_id = I.item_id AND RBI.book_id = A.book_id AND RBI.del_flg = 0
+INNER JOIN mst_category C ON I.category_id = C.category_id AND C.del_flg = 0
+INNER JOIN mst_asset DA ON DA.asset_id = @DefaultAssetId AND DA.del_flg = 0 -- デフォルトアセット(不使用)
+INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
+WHERE A.del_flg = 0 AND A.group_id = @GroupId;
+",
+new { GroupId = groupId, DefaultAssetId = defaultAssetId });
+
+            return dtoList;
+        }
+
+        /// <summary>
         /// 全帳簿の <see cref="ActionInfoDto"/> リストを取得する
         /// </summary>
         /// <param name="defaultAssetId">デフォルトアセットID</param>
@@ -27,14 +84,16 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDao.Compositions
             using FuncLog funcLog = new(new { defaultAssetId, startDate, finishDate }, Log.LogLevel.Trace);
 
             IEnumerable<ActionInfoDto> dtoList = await this.mDbHandler.QueryAsync<ActionInfoDto>(@"
-SELECT A.action_id, A.act_time, B.book_id, C.category_id, I.item_id, B.book_name, C.category_name, 
-       I.item_name, (A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base_rate AS act_main_value, A.shop_name, A.group_id, A.remark, A.is_match
+SELECT A.action_id, A.act_time, B.book_id, C.category_id, I.item_id, B.book_name, C.category_name, I.item_name, A.asset_id,
+       (A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base_rate AS main_act_value, DA.asset_id AS act_asset_id,
+       (A.act_value / POWER(10, AA.scale)) AS org_main_act_value, AA.asset_id AS org_act_asset_id,
+       A.shop_name, A.group_id, A.remark, A.is_match
 FROM hst_action A
 INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0 
 INNER JOIN mst_item I ON I.item_id = A.item_id AND I.move_flg = 0 AND I.del_flg = 0 
 INNER JOIN rel_book_item RBI ON RBI.item_id = I.item_id AND RBI.book_id = A.book_id AND RBI.del_flg = 0
 INNER JOIN mst_category C ON I.category_id = C.category_id AND C.del_flg = 0
-INNER JOIN mst_asset DA ON DA.asset_id = @DefaultAssetId AND DA.del_flg = 0 -- 表示するアセット(デフォルトアセット)
+INNER JOIN mst_asset DA ON DA.asset_id = @DefaultAssetId AND DA.del_flg = 0 -- デフォルトアセット
 INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
 WHERE A.del_flg = 0 AND @StartDate <= A.act_time AND A.act_time < @FinishDate
 ORDER BY act_time, balance_kind, C.sort_order, I.sort_order, B.sort_order, action_id;
@@ -57,15 +116,17 @@ new { DefaultAssetId = defaultAssetId, StartDate = startDate, FinishDate = finis
             using FuncLog funcLog = new(new { bookId, defaultAssetId, startDate, finishDate }, Log.LogLevel.Trace);
 
             IEnumerable<ActionInfoDto> dtoList = await this.mDbHandler.QueryAsync<ActionInfoDto>(@"
-SELECT A.action_id, A.act_time, B.book_id, C.category_id, I.item_id, B.book_name, C.category_name,
-       I.item_name, (A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate AS act_main_value, A.shop_name, A.group_id, A.remark, A.is_match
+SELECT A.action_id, A.act_time, B.book_id, C.category_id, I.item_id, B.book_name, C.category_name, I.item_name, A.asset_id,
+       (A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate AS main_act_value, BA.asset_id AS act_asset_id,
+       (A.act_value / POWER(10, AA.scale)) AS org_main_act_value, AA.asset_id AS org_act_asset_id,
+       A.shop_name, A.group_id, A.remark, A.is_match
 FROM hst_action A
 INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0
 INNER JOIN mst_item I ON I.item_id = A.item_id AND (EXISTS (
     SELECT * FROM rel_book_item RBI 
     WHERE RBI.item_id = I.item_id AND RBI.book_id = B.book_id AND RBI.del_flg = 0) OR I.move_flg = 1) AND I.del_flg = 0
 INNER JOIN mst_category C ON I.category_id = C.category_id AND C.del_flg = 0
-INNER JOIN mst_asset BA ON BA.asset_id = COALESCE(B.asset_id, @DefaultAssetId) AND BA.del_flg = 0 -- 表示するアセット(帳簿に紐づくアセット)
+INNER JOIN mst_asset BA ON BA.asset_id = COALESCE(B.asset_id, @DefaultAssetId) AND BA.del_flg = 0 -- 帳簿に紐づくアセット
 INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
 WHERE A.del_flg = 0 AND B.book_id = @BookId AND @StartDate <= A.act_time AND A.act_time < @FinishDate
 ORDER BY act_time, balance_kind, C.sort_order, I.move_flg DESC, I.sort_order, B.sort_order, action_id;",

--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/EndingBalanceInfoDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/EndingBalanceInfoDao.cs
@@ -29,13 +29,14 @@ SELECT COALESCE(SUM((A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base
     SELECT COALESCE(SUM((BB.initial_value / POWER(10, MAA.scale)) * MAA.base_rate / MDA.base_rate), 0)
     FROM mst_book BB
     INNER JOIN mst_asset MDA ON MDA.asset_id = @DefaultAssetId AND MDA.del_flg = 0 -- 表示するアセット(デフォルトアセット)
-	INNER JOIN mst_asset MAA ON MAA.asset_id = COALESCE(BB.asset_id, @DefaultAssetId) AND MAA.del_flg = 0 -- 帳簿に紐づくアセット
-	WHERE BB.del_flg = 0) AS ending_main_balance
-FROM hst_action A
-INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0
+    INNER JOIN mst_asset MAA ON MAA.asset_id = COALESCE(BB.asset_id, @DefaultAssetId) AND MAA.del_flg = 0 -- 帳簿に紐づくアセット
+    WHERE BB.del_flg = 0) AS main_ending_balance, DA.asset_id
+FROM mst_book B
 INNER JOIN mst_asset DA ON DA.asset_id = @DefaultAssetId AND DA.del_flg = 0 -- 表示するアセット(デフォルトアセット)
-INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
-WHERE A.del_flg = 0 AND A.act_time < @StartDate;",
+LEFT JOIN hst_action A ON A.book_id = B.book_id AND A.del_flg = 0 AND A.act_time < @StartDate
+LEFT JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
+WHERE B.del_flg = 0
+GROUP BY DA.asset_id;",
 new { DefaultAssetId = defaultAssetId, StartDate = startDate });
 
             return dto;
@@ -55,14 +56,15 @@ new { DefaultAssetId = defaultAssetId, StartDate = startDate });
             EndingBalanceInfoDto dto = await this.mDbHandler.QuerySingleAsync<EndingBalanceInfoDto>(@"
 SELECT COALESCE(SUM((A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate), 0) + (
     SELECT BB.initial_value / POWER(10, MAA.scale)
-	FROM mst_book BB
-	INNER JOIN mst_asset MAA ON MAA.asset_id = COALESCE(BB.asset_id, @DefaultAssetId) AND MAA.del_flg = 0 -- 表示するアセット(帳簿に紐づくアセット)
-	WHERE BB.book_id = @BookId AND BB.del_flg = 0) AS ending_main_balance
-FROM hst_action A
-INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0
+    FROM mst_book BB
+    INNER JOIN mst_asset MAA ON MAA.asset_id = COALESCE(BB.asset_id, @DefaultAssetId) AND MAA.del_flg = 0 -- 表示するアセット(帳簿に紐づくアセット)
+    WHERE BB.book_id = @BookId AND BB.del_flg = 0) AS main_ending_balance, BA.asset_id
+FROM mst_book B
 INNER JOIN mst_asset BA ON BA.asset_id = COALESCE(B.asset_id, @DefaultAssetId) AND BA.del_flg = 0 -- 表示するアセット(帳簿に紐づくアセット)
-INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
-WHERE A.book_id = @BookId AND A.del_flg = 0 AND A.act_time < @StartDate;",
+LEFT JOIN hst_action A ON A.book_id = B.book_id AND A.del_flg = 0 AND A.act_time < @StartDate
+LEFT JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
+WHERE B.book_id = @BookId AND B.del_flg = 0
+GROUP BY BA.asset_id;",
 new { BookId = bookId, DefaultAssetId = defaultAssetId, StartDate = startDate });
 
             return dto;

--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/MoveActionInfoDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/MoveActionInfoDao.cs
@@ -25,11 +25,15 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDao.Compositions
             using FuncLog funcLog = new(new { defaultAssetId, groupId }, Log.LogLevel.Trace);
 
             IEnumerable<MoveActionInfoDto> dtoList = await this.mDbHandler.QueryAsync<MoveActionInfoDto>(@"
-SELECT A.book_id, A.action_id, A.item_id, A.act_time, A.act_value / POWER(10, MA.scale) AS act_main_value, A.remark, I.move_flg
+SELECT A.book_id, A.action_id, A.item_id, A.act_time, A.asset_id,
+       (A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate AS main_act_value, BA.asset_id AS act_asset_id,
+       (A.act_value / POWER(10, AA.scale)) AS org_main_act_value, AA.asset_id AS org_act_asset_id,
+       A.remark, I.move_flg
 FROM hst_action A
 INNER JOIN mst_item I ON I.item_id = A.item_id AND I.del_flg = 0
 INNER JOIN mst_book B ON B.book_id = A.book_id AND B.del_flg = 0
-INNER JOIN mst_asset MA ON MA.asset_id = @DefaultAssetId AND MA.del_flg = 0
+INNER JOIN mst_asset BA ON BA.asset_id = COALESCE(B.asset_id, @DefaultAssetId) AND BA.del_flg = 0 -- 表示するアセット(帳簿に紐づくアセット)
+INNER JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
 WHERE A.del_flg = 0 AND A.group_id = @GroupId
 ORDER BY I.move_flg DESC;",
 new { DefaultAssetId = defaultAssetId, GroupId = groupId });

--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/SummaryInfoDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/Compositions/SummaryInfoDao.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace HouseholdAccountBook.Infrastructure.DB.DbDao.Compositions
 {
     /// <summary>
-    /// 帳簿情報DAO
+    /// 概要情報DAO
     /// </summary>
     /// <param name="dbHandler">DBハンドラ</param>
     public class SummaryInfoDao(DbHandlerBase dbHandler) : TableDaoBase(dbHandler)
@@ -27,7 +27,8 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDao.Compositions
             using FuncLog funcLog = new(new { defaultAssetId, startDate, finishDate }, Log.LogLevel.Trace);
 
             IEnumerable<SummaryInfoDto> dtoList = await this.mDbHandler.QueryAsync<SummaryInfoDto>(@"
-SELECT C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name, COALESCE(SUM((A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base_rate), 0) AS main_total
+SELECT C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name,
+       COALESCE(SUM((A.act_value / POWER(10, AA.scale)) * AA.base_rate / DA.base_rate), 0) AS main_total, DA.asset_id
 FROM mst_item I
 INNER JOIN rel_book_item RBI ON RBI.item_id = I.item_id AND RBI.del_flg = 0
 INNER JOIN mst_category C ON C.category_id = I.category_id AND C.del_flg = 0
@@ -36,7 +37,7 @@ LEFT JOIN hst_action A ON A.item_id = I.item_id AND A.book_id = B.book_id AND A.
 LEFT JOIN mst_asset DA ON DA.asset_id = @DefaultAssetId AND DA.del_flg = 0 -- 表示するアセット(デフォルトアセット)
 LEFT JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id, @DefaultAssetId)) AND AA.del_flg = 0 -- 帳簿項目に紐づくアセット
 WHERE I.move_flg = 0 AND I.del_flg = 0
-GROUP BY C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name, C.sort_order, I.sort_order
+GROUP BY C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name, DA.asset_id, C.sort_order, I.sort_order
 ORDER BY C.balance_kind, C.sort_order, I.sort_order;",
 new { DefaultAssetId = defaultAssetId, StartDate = startDate, FinishDate = finishDate.AddDays(1) });
 
@@ -56,7 +57,8 @@ new { DefaultAssetId = defaultAssetId, StartDate = startDate, FinishDate = finis
             using FuncLog funcLog = new(new { bookId, defaultAssetId, startDate, finishDate }, Log.LogLevel.Trace);
 
             IEnumerable<SummaryInfoDto> dtoList = await this.mDbHandler.QueryAsync<SummaryInfoDto>(@"
-SELECT C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name, COALESCE(SUM((A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate), 0) AS main_total
+SELECT C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name,
+       COALESCE(SUM((A.act_value / POWER(10, AA.scale)) * AA.base_rate / BA.base_rate), 0) AS main_total, BA.asset_id
 FROM mst_item I
 INNER JOIN mst_category C ON C.category_id = I.category_id AND C.del_flg = 0
 INNER JOIN mst_book B ON B.book_id = @BookId AND B.del_flg = 0
@@ -66,7 +68,7 @@ LEFT JOIN mst_asset AA ON AA.asset_id = COALESCE(A.asset_id, COALESCE(B.asset_id
 WHERE (EXISTS (
     SELECT * FROM rel_book_item RBI
     WHERE RBI.item_id = I.item_id AND RBI.book_id = B.book_id AND RBI.del_flg = 0) OR I.move_flg = 1) AND I.del_flg = 0
-GROUP BY C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name, C.sort_order, I.move_flg, I.sort_order
+GROUP BY C.balance_kind, C.category_id, C.category_name, I.item_id, I.item_name, BA.asset_id, C.sort_order, I.move_flg, I.sort_order
 ORDER BY C.balance_kind, C.sort_order, I.move_flg DESC, I.sort_order;",
 new { BookId = bookId, DefaultAssetId = defaultAssetId, StartDate = startDate, FinishDate = finishDate.AddDays(1) });
 

--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/DbTable/HstActionDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/DbTable/HstActionDao.cs
@@ -151,6 +151,24 @@ new HstActionDto { BookId = bookId, ItemId = itemId });
             return dtoList;
         }
 
+        /// <summary>
+        /// <see cref="HstActionDto.AssetId"/> に基づいて、レコードを取得する
+        /// </summary>
+        /// <param name="assetId">アセットID</param>
+        /// <returns>取得したレコードリスト</returns>
+        public async Task<IEnumerable<HstActionDto>> FindByAssetIdAsync(int assetId)
+        {
+            using FuncLog funcLog = new(new { assetId }, Log.LogLevel.Trace);
+
+            IEnumerable<HstActionDto> dtoList = await this.mDbHandler.QueryAsync<HstActionDto>(@"
+SELECT *
+FROM hst_action
+WHERE asset_id = @AssetId AND del_flg = 0;",
+new HstActionDto { AssetId = assetId });
+
+            return dtoList;
+        }
+
         public override async Task SetIdSequenceAsync(int idSeq)
         {
             using FuncLog funcLog = new(new { idSeq }, Log.LogLevel.Trace);

--- a/HouseholdAccountBook/Infrastructure/DB/DbDao/DbTable/MstBookDao.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDao/DbTable/MstBookDao.cs
@@ -61,6 +61,24 @@ new MstBookDto { BookId = bookId });
         }
 
         /// <summary>
+        /// <see cref="MstBookDto.AssetId"/> に基づいて、レコードを取得する
+        /// </summary>
+        /// <param name="assetId">アセットID</param>
+        /// <returns>取得したレコードリスト</returns>
+        public async Task<IEnumerable<MstBookDto>> FindByAssetIdAsync(int assetId)
+        {
+            using FuncLog funcLog = new(new { assetId }, Log.LogLevel.Trace);
+
+            IEnumerable<MstBookDto> dtoList = await this.mDbHandler.QueryAsync<MstBookDto>(@"
+SELECT *
+FROM mst_book
+WHERE asset_id = @AssetId AND del_flg = 0;",
+new MstBookDto { AssetId = assetId });
+
+            return dtoList;
+        }
+
+        /// <summary>
         /// <see cref="MstBookDto.JsonCode"/> が空ではない全てのレコードを取得する
         /// </summary>
         /// <returns>取得したレコードリスト</returns>

--- a/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/ActionCompInfoDto.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/ActionCompInfoDto.cs
@@ -30,9 +30,25 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDto.Others
         /// </summary>
         public string ItemName { get; set; } = string.Empty;
         /// <summary>
-        /// 支出(主単位)
+        /// 帳簿項目のアセットID
         /// </summary>
-        public decimal ActMainValue { get; set; }
+        public int? AssetId { get; set; }
+        /// <summary>
+        /// 帳簿項目アセットでの項目値(主単位)
+        /// </summary>
+        public decimal OrgMainActValue { get; set; }
+        /// <summary>
+        /// 帳簿項目アセットでのアセットID
+        /// </summary>
+        public int OrgActAssetId { get; set; }
+        /// <summary>
+        /// 表示アセットでの支出(主単位)
+        /// </summary>
+        public decimal MainActValue { get; set; }
+        /// <summary>
+        /// 表示アセットでのアセットID
+        /// </summary>
+        public int ActAssetId { get; set; }
         /// <summary>
         /// 店舗名
         /// </summary>

--- a/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/ActionInfoDto.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/ActionInfoDto.cs
@@ -46,9 +46,25 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDto.Others
         /// </summary>
         public string ItemName { get; set; } = string.Empty;
         /// <summary>
-        /// 項目値(主単位)
+        /// 帳簿項目のアセットID
         /// </summary>
-        public decimal ActMainValue { get; set; }
+        public int? AssetId { get; set; }
+        /// <summary>
+        /// 帳簿項目アセットでの項目値(主単位)
+        /// </summary>
+        public decimal OrgMainActValue { get; set; }
+        /// <summary>
+        /// 帳簿項目アセットでのアセットID
+        /// </summary>
+        public int OrgActAssetId { get; set; }
+        /// <summary>
+        /// デフォルトまたは帳簿アセットでの項目値(主単位)
+        /// </summary>
+        public decimal MainActValue { get; set; }
+        /// <summary>
+        /// デフォルトまたは帳簿アセットでのアセットID
+        /// </summary>
+        public int ActAssetId { get; set; }
         /// <summary>
         /// 店舗名
         /// </summary>

--- a/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/EndingBalanceInfoDto.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/EndingBalanceInfoDto.cs
@@ -15,6 +15,10 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDto.Others
         /// <summary>
         /// 繰越残高(主単位)
         /// </summary>
-        public decimal EndingMainBalance { get; set; }
+        public decimal MainEndingBalance { get; set; }
+        /// <summary>
+        /// アセットID
+        /// </summary>
+        public int AssetId { get; set; }
     }
 }

--- a/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/MoveActionInfoDto.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/MoveActionInfoDto.cs
@@ -30,9 +30,25 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDto.Others
         /// </summary>
         public DateTime ActTime { get; set; } = DateTime.Now;
         /// <summary>
-        /// 項目値(主単位)
+        /// 帳簿項目のアセットID
         /// </summary>
-        public decimal ActMainValue { get; set; }
+        public int? AssetId { get; set; }
+        /// <summary>
+        /// 帳簿項目アセットでの項目値(主単位)
+        /// </summary>
+        public decimal OrgMainActValue { get; set; }
+        /// <summary>
+        /// 帳簿項目アセットでのアセットID
+        /// </summary>
+        public int OrgActAssetId { get; set; }
+        /// <summary>
+        /// 表示アセットでの項目値(主単位)
+        /// </summary>
+        public decimal MainActValue { get; set; }
+        /// <summary>
+        /// 表示アセットでのアセットID
+        /// </summary>
+        public int ActAssetId { get; set; }
         /// <summary>
         /// 備考
         /// </summary>

--- a/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/SummaryInfoDto.cs
+++ b/HouseholdAccountBook/Infrastructure/DB/DbDto/Others/SummaryInfoDto.cs
@@ -33,8 +33,12 @@ namespace HouseholdAccountBook.Infrastructure.DB.DbDto.Others
         /// </summary>
         public string ItemName { get; set; } = string.Empty;
         /// <summary>
-        /// 合計(主単位)
+        /// 表示アセットでの合計(主単位)
         /// </summary>
         public decimal MainTotal { get; set; }
+        /// <summary>
+        /// 表示アセットでのアセットID
+        /// </summary>
+        public int AssetId { get; set; }
     }
 }

--- a/HouseholdAccountBook/Models/AppServices/ActionRegService.cs
+++ b/HouseholdAccountBook/Models/AppServices/ActionRegService.cs
@@ -27,6 +27,7 @@ namespace HouseholdAccountBook.Models.AppServices
         /// </summary>
         private readonly DbHandlerFactory mDbHandlerFactory = dbHandlerFactory;
 
+        #region 帳簿項目
         /// <summary>
         /// 帳簿項目Modelを取得する
         /// </summary>
@@ -37,18 +38,16 @@ namespace HouseholdAccountBook.Models.AppServices
             using FuncLog funcLog = new(new { actionId });
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
-            HstActionDao hstActionDao = new(dbHandler);
-            HstActionDto dto = await hstActionDao.FindByIdAsync((int)actionId);
-
-            MstAssetDao mstAssetDao = new(dbHandler);
-            MstAssetDto mstAssetDto = await mstAssetDao.FindByIdAsync((int)UserSettingService.Instance.DefaultAssetId);
+            ActionInfoDao dao = new(dbHandler);
+            ActionInfoDto dto = await dao.FindByActionIdAsync((int)actionId, (int)UserSettingService.Instance.DefaultAssetId);
 
             ActionModel action = new() {
-                Base = new(dto.ActionId, dto.ActTime, AmountObj.FromSubValue(dto.ActValue, mstAssetDto.Scale)),
+                Base = new(dto.ActionId, dto.ActTime, new(dto.OrgMainActValue, dto.OrgActAssetId)),
+                AssetId = dto.AssetId ?? AssetIdObj.System,
                 GroupId = dto.GroupId,
-                Account = new(dto.BookId, string.Empty),
-                Category = new(null, string.Empty, 0 < Math.Sign(dto.ActValue) ? BalanceKind.Income : BalanceKind.Expenses),
-                Item = new(dto.ItemId, string.Empty),
+                Account = new(dto.BookId, dto.BookName),
+                Category = new(dto.CategoryId, dto.CategoryName, 0 < Math.Sign(dto.OrgMainActValue) ? BalanceKind.Income : BalanceKind.Expenses),
+                Item = new(dto.ItemId, dto.ItemName),
                 Shop = new(dto.ShopName),
                 Remark = new(dto.Remark),
                 IsMatch = dto.IsMatch == 1
@@ -132,6 +131,7 @@ namespace HouseholdAccountBook.Models.AppServices
                             ItemId = (int)action.Item.Id,
                             ActTime = tmpActTime,
                             ActValue = action.Amount.SubValue,
+                            AssetId = null, // TODO: 将来の拡張用
                             ShopName = action.Shop,
                             GroupId = (int?)assingedGroupId,
                             Remark = action.Remark
@@ -155,6 +155,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                 ItemId = (int)action.Item.Id,
                                 ActTime = action.ActTime,
                                 ActValue = action.Amount.SubValue,
+                                AssetId = null, // TODO: 将来の拡張用
                                 ShopName = action.Shop,
                                 GroupId = null,
                                 Remark = action.Remark,
@@ -179,6 +180,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                     ItemId = (int)action.Item.Id,
                                     ActTime = action.ActTime,
                                     ActValue = action.Amount.SubValue,
+                                    AssetId = null, // TODO: 将来の拡張用
                                     ShopName = action.Shop,
                                     GroupId = null,
                                     Remark = action.Remark,
@@ -198,6 +200,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                     ItemId = (int)action.Item.Id,
                                     ActTime = action.ActTime,
                                     ActValue = action.Amount.SubValue,
+                                    AssetId = null, // TODO: 将来の拡張用
                                     ShopName = action.Shop,
                                     GroupId = (int?)action.GroupId,
                                     Remark = action.Remark,
@@ -239,6 +242,7 @@ namespace HouseholdAccountBook.Models.AppServices
                             ItemId = (int)action.Item.Id,
                             ActTime = tmpActTime,
                             ActValue = action.Amount.SubValue,
+                            AssetId = null, // TODO: 将来の拡張用
                             ShopName = action.Shop,
                             GroupId = (int?)assignedGroupId,
                             Remark = action.Remark,
@@ -259,6 +263,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                         ItemId = (int)action.Item.Id,
                                         ActTime = tmpActTime,
                                         ActValue = action.Amount.SubValue,
+                                        AssetId = null, // TODO: 将来の拡張用
                                         ShopName = action.Shop,
                                         GroupId = (int?)assignedGroupId,
                                         Remark = action.Remark,
@@ -282,6 +287,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                 ItemId = (int)action.Item.Id,
                                 ActTime = tmpActTime,
                                 ActValue = action.Amount.SubValue,
+                                AssetId = null, // TODO: 将来の拡張用
                                 ShopName = action.Shop,
                                 GroupId = (int?)assignedGroupId,
                                 Remark = action.Remark,
@@ -298,7 +304,9 @@ namespace HouseholdAccountBook.Models.AppServices
 
             return resActionId;
         }
+        #endregion
 
+        #region 帳簿項目リスト
         /// <summary>
         /// 帳簿項目Modelリストを取得する
         /// </summary>
@@ -309,20 +317,18 @@ namespace HouseholdAccountBook.Models.AppServices
             using FuncLog funcLog = new(new { groupId });
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
-            HstActionDao hstActionDao = new(dbHandler);
-            IEnumerable<HstActionDto> dtoList = await hstActionDao.FindByGroupIdAsync((int)groupId);
+            ActionInfoDao dao = new(dbHandler);
+            IEnumerable<ActionInfoDto> dtoList = await dao.FindByGroupIdAsync((int)groupId, (int)UserSettingService.Instance.DefaultAssetId);
 
             List<ActionModel> actionList = [];
-            foreach (HstActionDto dto in dtoList) {
-                MstAssetDao mstAssetDao = new(dbHandler);
-                MstAssetDto mstAssetDto = await mstAssetDao.FindByIdAsync((int)UserSettingService.Instance.DefaultAssetId);
-
+            foreach (ActionInfoDto dto in dtoList) {
                 ActionModel action = new() {
+                    Base = new(dto.ActionId, dto.ActTime, new(dto.OrgMainActValue, dto.OrgActAssetId)),
+                    AssetId = dto.AssetId ?? AssetIdObj.System,
                     GroupId = groupId,
-                    Account = new(dto.BookId, string.Empty),
-                    Category = new(null, string.Empty, 0 < Math.Sign(dto.ActValue) ? BalanceKind.Income : BalanceKind.Expenses),
-                    Item = new(dto.ItemId, string.Empty),
-                    Base = new(dto.ActionId, dto.ActTime, AmountObj.FromSubValue(dto.ActValue, mstAssetDto.Scale)),
+                    Account = new(dto.BookId, dto.BookName),
+                    Category = new(dto.CategoryId, dto.CategoryName, 0 < Math.Sign(dto.OrgMainActValue) ? BalanceKind.Income : BalanceKind.Expenses),
+                    Item = new(dto.ItemId, dto.ItemName),
                     Shop = new(dto.ShopName),
                     Remark = new(dto.Remark)
                 };
@@ -357,6 +363,7 @@ namespace HouseholdAccountBook.Models.AppServices
                             ItemId = (int)action.Item.Id,
                             ActTime = action.ActTime,
                             ActValue = action.Amount.SubValue,
+                            AssetId = null, // TODO: 将来の拡張用
                             ShopName = action.Shop,
                             GroupId = (int?)assignedGroupId,
                             Remark = action.Remark
@@ -377,6 +384,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                 ItemId = (int)action.Item.Id,
                                 ActTime = action.ActTime,
                                 ActValue = action.Amount.SubValue,
+                                AssetId = null, // TODO: 将来の拡張用
                                 ShopName = action.Shop,
                                 Remark = action.Remark,
                                 GroupId = (int?)action.GroupId,
@@ -391,6 +399,7 @@ namespace HouseholdAccountBook.Models.AppServices
                                 ItemId = (int)action.Item.Id,
                                 ActTime = action.ActTime,
                                 ActValue = action.Amount.SubValue,
+                                AssetId = null, // TODO: 将来の拡張用
                                 ShopName = action.Shop,
                                 Remark = action.Remark,
                                 GroupId = (int?)action.GroupId
@@ -411,7 +420,9 @@ namespace HouseholdAccountBook.Models.AppServices
 
             return resActionIdList;
         }
+        #endregion
 
+        #region 移動
         /// <summary>
         /// 移動帳簿項目Modelを取得する
         /// </summary>
@@ -421,21 +432,23 @@ namespace HouseholdAccountBook.Models.AppServices
         {
             using FuncLog funcLog = new(new { groupId });
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
             MoveActionInfoDao moveActionInfoDao = new(dbHandler);
             // 移動元、移動先、手数料の順に並び替え
             IEnumerable<MoveActionInfoDto> dtoList = await moveActionInfoDao.GetAllAsync((int)UserSettingService.Instance.DefaultAssetId, (int)groupId);
-            dtoList = dtoList.OrderBy(dto => dto.ActMainValue).OrderBy(dto => -dto.MoveFlg);
+            dtoList = dtoList.OrderBy(dto => dto.MainActValue).OrderBy(dto => -dto.MoveFlg);
 
             List<ActionModel> actionList = [];
             foreach (MoveActionInfoDto dto in dtoList) {
                 ActionModel action = new() {
+                    Base = new(dto.ActionId, dto.ActTime, new(dto.MainActValue, dto.ActAssetId)),
+                    AssetId = dto.AssetId ?? AssetIdObj.System,
                     GroupId = groupId,
                     Account = new(dto.BookId, string.Empty),
+                    Category = null,
                     Item = new(dto.ItemId, string.Empty),
-                    Base = new(dto.ActionId, dto.ActTime, new(dto.ActMainValue, asset.Scale)),
+                    Shop = null,
                     Remark = new(dto.Remark)
                 };
                 actionList.Add(action);
@@ -469,19 +482,23 @@ namespace HouseholdAccountBook.Models.AppServices
                     HstGroupDao hstGroupDao = new(dbHandler);
                     assignedGroupId = await hstGroupDao.InsertReturningIdAsync(new HstGroupDto { GroupKind = (int)GroupKind.Move });
 
+                    // 移動元
                     HstActionDao hstActionDao = new(dbHandler);
                     ActionIdObj fromActionId = await hstActionDao.InsertMoveActionReturningIdAsync(new HstActionDto {
                         BookId = (int)fromAction.Account.Id,
                         ActTime = fromAction.ActTime,
                         ActValue = fromAction.Amount.SubValue,
+                        AssetId = null, // TODO: 将来の拡張用
                         GroupId = (int?)assignedGroupId
                     }, (int)BalanceKind.Expenses);
                     resActionIdList.Add(fromActionId);
 
+                    // 移動先
                     ActionIdObj toActionId = await hstActionDao.InsertMoveActionReturningIdAsync(new HstActionDto {
                         BookId = (int)toAction.Account.Id,
                         ActTime = toAction.ActTime,
                         ActValue = toAction.Amount.SubValue,
+                        AssetId = null, // TODO: 将来の拡張用
                         GroupId = (int?)assignedGroupId
                     }, (int)BalanceKind.Income);
                     resActionIdList.Add(toActionId);
@@ -489,19 +506,23 @@ namespace HouseholdAccountBook.Models.AppServices
                 }
                 else {
                     #region 帳簿項目を変更する
+                    // 移動元
                     HstActionDao hstActionDao = new(dbHandler);
                     _ = await hstActionDao.UpdateMoveActionAsync(new HstActionDto {
                         BookId = (int)fromAction.Account.Id,
                         ActTime = fromAction.ActTime,
                         ActValue = fromAction.Amount.SubValue,
+                        AssetId = null, // TODO: 将来の拡張用
                         ActionId = (int)fromAction.ActionId
                     });
                     resActionIdList.Add(fromAction.ActionId);
 
+                    // 移動先
                     _ = await hstActionDao.UpdateMoveActionAsync(new HstActionDto {
                         BookId = (int)toAction.Account.Id,
                         ActTime = toAction.ActTime,
                         ActValue = toAction.Amount.SubValue,
+                        AssetId = null, // TODO: 将来の拡張用
                         ActionId = (int)toAction.ActionId
                     });
                     resActionIdList.Add(toAction.ActionId);
@@ -518,6 +539,7 @@ namespace HouseholdAccountBook.Models.AppServices
                             ItemId = (int)commissionAction.Item.Id,
                             ActTime = commissionAction.ActTime,
                             ActValue = commissionAction.Amount.SubValue,
+                            AssetId = null, // TODO: 将来の拡張用
                             Remark = commissionAction.Remark,
                             GroupId = (int?)assignedGroupId
                         });
@@ -531,6 +553,7 @@ namespace HouseholdAccountBook.Models.AppServices
                             ItemId = (int)commissionAction.Item.Id,
                             ActTime = commissionAction.ActTime,
                             ActValue = commissionAction.Amount.SubValue,
+                            AssetId = null, // TODO: 将来の拡張用
                             Remark = commissionAction.Remark,
                             GroupId = (int?)assignedGroupId,
                             ActionId = (int)commissionAction.ActionId
@@ -551,6 +574,7 @@ namespace HouseholdAccountBook.Models.AppServices
 
             return resActionIdList;
         }
+        #endregion
 
         /// <summary>
         /// 店舗情報を保存する

--- a/HouseholdAccountBook/Models/AppServices/ActionViewService.cs
+++ b/HouseholdAccountBook/Models/AppServices/ActionViewService.cs
@@ -98,14 +98,13 @@ namespace HouseholdAccountBook.Models.AppServices
         {
             using FuncLog funcLog = new(new { accountId, startDate });
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
             EndingBalanceInfoDao endingBalanceInfoDao = new(dbHandler);
             EndingBalanceInfoDto dto = accountId == AccountIdObj.System
                 ? await endingBalanceInfoDao.Find((int)UserSettingService.Instance.DefaultAssetId, startDate) // 全帳簿の繰越残高
                 : await endingBalanceInfoDao.FindByBookId(accountId.Id, (int)UserSettingService.Instance.DefaultAssetId, startDate); // 各帳簿の繰越残高
-            AmountObj balance = new(dto.EndingMainBalance, asset.Scale);
+            AmountObj balance = new(dto.MainEndingBalance, dto.AssetId);
 
             return balance;
         }
@@ -135,7 +134,6 @@ namespace HouseholdAccountBook.Models.AppServices
         {
             using FuncLog funcLog = new(new { accountId, period });
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
             List<ActionWithBalanceModel> amList = [];
@@ -145,10 +143,12 @@ namespace HouseholdAccountBook.Models.AppServices
             {
                 ActionWithBalanceModel am = new() {
                     Action = new() {
+                        Base = new(ActionIdObj.System, period.Start.ToDateTime(TimeOnly.MinValue), new(0m, balance.AssetId)),
+                        AssetId = null,
+                        GroupId = null,
                         Account = new(AccountIdObj.System, string.Empty),
                         Category = new(CategoryIdObj.System, string.Empty, BalanceKind.Others),
                         Item = new(ItemIdObj.System, Properties.Resources.ListName_CarryForward),
-                        Base = new(ActionIdObj.System, period.Start.ToDateTime(TimeOnly.MinValue), new(0m, asset.Scale)),
                         Shop = null,
                         Remark = null,
                         IsMatch = false
@@ -164,15 +164,17 @@ namespace HouseholdAccountBook.Models.AppServices
                 : await actionInfoDao.FindByBookIdWithinPeriod((int)accountId, (int)UserSettingService.Instance.DefaultAssetId, period.Start, period.End); // 各帳簿項目
 
             foreach (ActionInfoDto aDto in dtoList) {
-                balance += new AmountObj(aDto.ActMainValue, asset.Scale);
+                AmountObj actValue = new(aDto.MainActValue, aDto.ActAssetId);
+                balance += actValue;
 
                 ActionWithBalanceModel am = new() {
                     Action = new() {
+                        Base = new(aDto.ActionId, aDto.ActTime, actValue),
+                        AssetId = aDto.AssetId ?? AssetIdObj.System,
                         GroupId = aDto.GroupId,
                         Account = new(aDto.BookId, aDto.BookName),
-                        Category = new(aDto.CategoryId, aDto.CategoryName, aDto.ActMainValue < 0 ? BalanceKind.Expenses : BalanceKind.Income),
+                        Category = new(aDto.CategoryId, aDto.CategoryName, aDto.MainActValue < 0 ? BalanceKind.Expenses : BalanceKind.Income),
                         Item = new(aDto.ItemId, aDto.ItemName),
-                        Base = new(aDto.ActionId, aDto.ActTime, new(aDto.ActMainValue, asset.Scale)),
                         Shop = new(aDto.ShopName),
                         Remark = new(aDto.Remark),
                         IsMatch = aDto.IsMatch == 1
@@ -198,7 +200,7 @@ namespace HouseholdAccountBook.Models.AppServices
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
             HstActionDao hstActionDao = new(dbHandler);
-            _ = await hstActionDao.UpdateShopNameAndRemarkByIdAsync(actionId.Id, shopName, remark);
+            _ = await hstActionDao.UpdateShopNameAndRemarkByIdAsync((int)actionId, shopName, remark);
         }
 
         /// <summary>
@@ -212,7 +214,7 @@ namespace HouseholdAccountBook.Models.AppServices
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
             HstActionDao hstActionDao = new(dbHandler);
-            HstActionDto dto = await hstActionDao.FindByIdAsync(actionId.Id);
+            HstActionDto dto = await hstActionDao.FindByIdAsync((int)actionId);
             DateOnly actDate = DateOnly.FromDateTime(dto.ActTime);
 
             return actDate;
@@ -243,7 +245,8 @@ namespace HouseholdAccountBook.Models.AppServices
         {
             using FuncLog funcLog = new(new { accountId, period });
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
+            bool initAssetId = false;
+            AssetIdObj assetId = AssetIdObj.System;
 
             List<SummaryModel> smList = [];
             await using (DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync()) {
@@ -253,16 +256,21 @@ namespace HouseholdAccountBook.Models.AppServices
                     : await summaryInfoDao.FindByBookIdWithinPeriod((int)accountId, (int)UserSettingService.Instance.DefaultAssetId, period.Start, period.End);
 
                 foreach (SummaryInfoDto dto in dtoList) {
+                    if (!initAssetId) {
+                        assetId = dto.AssetId;
+                        initAssetId = true;
+                    }
+
                     smList.Add(new() {
                         Category = new(dto.CategoryId, dto.CategoryName, EnumUtil.SafeCastEnum(dto.BalanceKind, BalanceKind.Income)),
                         Item = new(dto.ItemId, dto.ItemName),
-                        Total = new(dto.MainTotal, asset.Scale)
+                        Total = new(dto.MainTotal, assetId)
                     });
                 }
             }
 
             // 差引損益
-            AmountObj total = new(smList.Sum(obj => obj.Total.MainValue), asset.Scale);
+            AmountObj total = new(smList.Sum(obj => obj.Total.MainValue), assetId);
             // 収入/支出
             List<SummaryModel> totalAsBalanceKindList = [];
             // 分類小計
@@ -273,13 +281,13 @@ namespace HouseholdAccountBook.Models.AppServices
                 // 収入/支出の小計を計算する
                 totalAsBalanceKindList.Add(new() {
                     Category = new(CategoryIdObj.System, string.Empty, g1.Key),
-                    Total = new(g1.Sum(obj => obj.Total.MainValue), asset.Scale)
+                    Total = new(g1.Sum(obj => obj.Total.MainValue), assetId)
                 });
                 // 分類別の小計を計算する
                 foreach (IGrouping<int, SummaryModel> g2 in g1.GroupBy(obj => (int)obj.Category.Id)) {
                     totalAsCategoryList.Add(new() {
                         Category = new(g2.Key, g2.First().Category.Name, g1.Key),
-                        Total = new(g2.Sum(obj => obj.Total.MainValue), asset.Scale)
+                        Total = new(g2.Sum(obj => obj.Total.MainValue), assetId)
                     });
                 }
             }

--- a/HouseholdAccountBook/Models/AppServices/AssetService.cs
+++ b/HouseholdAccountBook/Models/AppServices/AssetService.cs
@@ -53,7 +53,16 @@ namespace HouseholdAccountBook.Models.AppServices
         /// <summary>
         /// 金額を文字列表現に変換する
         /// </summary>
-        /// <param name="value">DB管理値(補助単位値)</param>
+        /// <param name="amount">金額VO</param>
+        /// <param name="outputKind">出力値単位種別</param>
+        /// <param name="position">単位位置</param>
+        /// <returns>金額の文字列表現</returns>
+        public string ToAssetString(AmountObj amount, UnitKind outputKind, UnitPosition position = UnitPosition.Both)
+            => this.ToAssetString(amount.MainValue, amount.AssetId, UnitKind.MainUnit, outputKind, position);
+        /// <summary>
+        /// 金額を文字列表現に変換する
+        /// </summary>
+        /// <param name="value">金額</param>
         /// <param name="assetId">アセットID</param>
         /// <param name="inputKind">入力値単位種別</param>
         /// <param name="outputKind">出力値単位種別</param>
@@ -63,7 +72,7 @@ namespace HouseholdAccountBook.Models.AppServices
         {
             using FuncLog funcLog = new(new { value, assetId, inputKind, outputKind, position }, Log.LogLevel.Trace);
 
-            AssetModel asset = this.mAssets.FirstOrDefault(asset => asset.Id == assetId, this.GetDefaultAssetModel());
+            AssetModel asset = this.GetAssetModel(assetId);
             if (asset is null) { return value.ToString(); }
 
             decimal tmpValue = value ?? 0;
@@ -115,25 +124,19 @@ namespace HouseholdAccountBook.Models.AppServices
         }
 
         /// <summary>
-        /// 変換元のDB管理値(補助単位値)を変換先のDB管理値(補助単位値)に変換する
+        /// 変換元の金額VOを変換先の金額VOに変換する
         /// </summary>
-        /// <param name="value">変換元のDB管理値(補助単位値)</param>
-        /// <param name="srcAssetId">変換元のアセットID</param>
+        /// <param name="src">変換元の金額VO</param>
         /// <param name="dstAssetId">変換先のアセットID。未指定の場合はデフォルトアセット</param>
-        /// <returns>変換先のDB管理値(補助単位値)</returns>
-        public decimal Convert(decimal value, AssetIdObj srcAssetId, AssetIdObj dstAssetId = null)
+        /// <returns>変換先の金額VO</returns>
+        public AmountObj Convert(AmountObj src, AssetIdObj dstAssetId = null)
         {
             dstAssetId ??= UserSettingService.Instance.DefaultAssetId;
 
-            AssetModel srcAsset = this.mAssets.FirstOrDefault(asset => asset.Id == srcAssetId);
-            AssetModel dstAsset = this.mAssets.FirstOrDefault(asset => asset.Id == dstAssetId);
+            AssetModel srcAsset = this.GetAssetModel(src.AssetId);
+            AssetModel dstAsset = this.GetAssetModel(dstAssetId);
 
-            decimal srcSubValue = value;
-            decimal srcMainValue = srcSubValue / (decimal)Math.Pow(10, srcAsset.Scale);
-            decimal dstMainValue = srcMainValue * srcAsset.BaseRate / dstAsset.BaseRate;
-            decimal dstSubValue = dstMainValue * (decimal)Math.Pow(10, dstAsset.Scale);
-
-            return dstSubValue;
+            return new(src.MainValue * srcAsset.BaseRate / dstAsset.BaseRate, dstAssetId);
         }
     }
 }

--- a/HouseholdAccountBook/Models/AppServices/CsvCompService.cs
+++ b/HouseholdAccountBook/Models/AppServices/CsvCompService.cs
@@ -45,6 +45,7 @@ namespace HouseholdAccountBook.Models.AppServices
                 if (jsonObj is null) { continue; }
 
                 AccountModel vm = new(dto.BookId, dto.BookName) {
+                    AssetId = dto.AssetId,
                     CsvFolderPath = jsonObj.CsvFolderPath == string.Empty ? null : jsonObj.CsvFolderPath,
                     TextEncoding = jsonObj.TextEncoding,
                     ActDateIndex = jsonObj.CsvActDateIndex + 1,
@@ -62,20 +63,20 @@ namespace HouseholdAccountBook.Models.AppServices
         /// <summary>
         /// 帳簿項目CSV Modelリストを取得する
         /// </summary>
+        /// <param name="assetId">取得するデータのアセットID</param>
         /// <param name="csvFilePathList">読み込むCSVファイルのパスリスト</param>
         /// <param name="actDateIndex">日付インデックス</param>
         /// <param name="itemNameIndex">項目名インデックス</param>
         /// <param name="expensesIndex">支出インデックス</param>
         /// <param name="encoding">エンコーディング</param>
         /// <returns>読込結果</returns>
-        public async Task<IEnumerable<ActionCsvModel>> LoadCsvCompListAsync(IEnumerable<string> csvFilePathList, int actDateIndex, int itemNameIndex, int expensesIndex, Encoding encoding)
+        public async Task<IEnumerable<ActionCsvModel>> LoadCsvCompListAsync(AssetIdObj assetId, IEnumerable<string> csvFilePathList, int actDateIndex, int itemNameIndex, int expensesIndex, Encoding encoding)
         {
             IEnumerable<ActionCsvDto> modelList = await CSVFileDao.LoadCsvCompListAsync(csvFilePathList, actDateIndex, itemNameIndex, expensesIndex, encoding);
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
             IEnumerable<ActionCsvModel> vmList = modelList.Select(x => new ActionCsvModel() {
                 Date = x.Date,
-                Value = new(x.Value, asset.Scale),
+                Value = new(x.Value, assetId),
                 Name = x.Name
             });
 
@@ -93,15 +94,15 @@ namespace HouseholdAccountBook.Models.AppServices
         {
             using FuncLog funcLog = new(new { accountId, dateTime, value });
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel(); // 帳簿に紐づくモデルに変更予定
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
 
             ActionCompInfoDao actionCompInfoDao = new(dbHandler);
             IEnumerable<ActionCompInfoDto> dtoList = await actionCompInfoDao.FindMatchesWithCsvAsync(accountId.Id, (int)UserSettingService.Instance.DefaultAssetId, dateTime, value.MainValue);
             IEnumerable<ActionModel> actionList = [.. dtoList.Select(dto => new ActionModel() {
+                    Base = new(dto.ActionId, dto.ActTime, new(dto.MainActValue, dto.ActAssetId)),
+                    AssetId = dto.AssetId ?? AssetIdObj.System,
                     GroupId = dto.GroupId,
                     Item = new(dto.ItemId, dto.ItemName),
-                    Base = new(dto.ActionId, dto.ActTime, new(dto.ActMainValue, asset.Scale)),
                     Shop = new(dto.ShopName),
                     Remark = new(dto.Remark),
                     IsMatch = dto.IsMatch == 1

--- a/HouseholdAccountBook/Models/AppServices/MasterSettingService.cs
+++ b/HouseholdAccountBook/Models/AppServices/MasterSettingService.cs
@@ -90,15 +90,30 @@ namespace HouseholdAccountBook.Models.AppServices
             bool result = false;
             await using DbHandlerBase dbHandler = await this.mDbHandlerFactory.CreateAsync();
             await dbHandler.ExecTransactionAsync(async () => {
-                // TODO: 紐づく帳簿を探す、紐づく帳簿項目を探す
-
-                if (UserSettingService.Instance.DefaultAssetId == assetId) {
+                // 紐づく帳簿を探す
+                MstBookDao bookDao = new(dbHandler);
+                IEnumerable<MstBookDto> bookDtoList = await bookDao.FindByAssetIdAsync((int)assetId);
+                if (bookDtoList.Any()) {
                     result = false;
                 }
                 else {
-                    MstAssetDao mstAssetDao = new(dbHandler);
-                    _ = await mstAssetDao.DeleteByIdAsync((int)assetId);
-                    result = true;
+                    // 紐づく帳簿項目を探す
+                    HstActionDao actionDao = new(dbHandler);
+                    IEnumerable<HstActionDto> actionDtoList = await actionDao.FindByAssetIdAsync((int)assetId);
+                    if (actionDtoList.Any()) {
+                        result = false;
+                    }
+                    else {
+                        // デフォルトアセットに設定されているか確認する
+                        if (UserSettingService.Instance.DefaultAssetId == assetId) {
+                            result = false;
+                        }
+                        else {
+                            MstAssetDao mstAssetDao = new(dbHandler);
+                            _ = await mstAssetDao.DeleteByIdAsync((int)assetId);
+                            result = true;
+                        }
+                    }
                 }
             });
             return result;
@@ -159,7 +174,6 @@ namespace HouseholdAccountBook.Models.AppServices
 
             BookInfoDao bookInfoDao = new(dbHandler);
             BookInfoDto dto = await bookInfoDao.FindByBookId((int)accountId, (int)UserSettingService.Instance.DefaultAssetId);
-            AssetModel asset = AssetService.Instance.GetAssetModel(dto.AssetId);
 
             MstBookDto.JsonDto jsonObj = dto.JsonCode == null ? null : new(dto.JsonCode);
 
@@ -168,7 +182,7 @@ namespace HouseholdAccountBook.Models.AppServices
                 AccountKind = EnumUtil.SafeCastEnum(dto.BookKind, AccountKind.Uncategorized),
                 AssetId = dto.AssetId,
                 Remark = jsonObj?.Remark ?? string.Empty,
-                InitialValue = new(dto.InitialMainValue, asset.Scale),
+                InitialValue = new(dto.InitialMainValue, dto.AssetId),
                 StartDateExists = jsonObj?.StartDate != null,
                 EndDateExists = jsonObj?.EndDate != null,
                 Period = new(jsonObj?.StartDate?.ToDateOnly() ?? dto.StartDate?.ToDateOnly() ?? DateOnlyExtensions.Today,

--- a/HouseholdAccountBook/Models/UiDto/ActionModel.cs
+++ b/HouseholdAccountBook/Models/UiDto/ActionModel.cs
@@ -12,6 +12,15 @@ namespace HouseholdAccountBook.Models.UiDto
     {
         #region プロパティ
         /// <summary>
+        /// 帳簿項目 基本Model
+        /// </summary>
+        public ActionBaseModel Base { get; init; } = new(ActionIdObj.System, DateTime.Now, new(0m, AssetIdObj.System));
+        /// <summary>
+        /// 帳簿項目のアセットID
+        /// </summary>
+        public AssetIdObj AssetId { get; init; }
+
+        /// <summary>
         /// グループID
         /// </summary>
         public GroupIdObj GroupId { get; init; } // = null;
@@ -28,11 +37,6 @@ namespace HouseholdAccountBook.Models.UiDto
         /// 項目
         /// </summary>
         public ItemModel Item { get; init; } = new(ItemIdObj.System, string.Empty);
-
-        /// <summary>
-        /// 帳簿項目 基本Model
-        /// </summary>
-        public ActionBaseModel Base { get; init; } = new(ActionIdObj.System, DateTime.Now, new(0m));
 
         /// <summary>
         /// 店舗名

--- a/HouseholdAccountBook/Models/UiDto/ActionWithBalanceModel.cs
+++ b/HouseholdAccountBook/Models/UiDto/ActionWithBalanceModel.cs
@@ -18,7 +18,7 @@ namespace HouseholdAccountBook.Models.UiDto
         /// <summary>
         /// 残高(主単位)
         /// </summary>
-        public AmountObj Balance { get; init; } = new(0m);
+        public AmountObj Balance { get; init; } = new(0m, AssetIdObj.System);
         #endregion
     }
 }

--- a/HouseholdAccountBook/Models/UiDto/SummaryModel.cs
+++ b/HouseholdAccountBook/Models/UiDto/SummaryModel.cs
@@ -45,7 +45,7 @@ namespace HouseholdAccountBook.Models.UiDto
         /// <summary>
         /// 合計(主単位)
         /// </summary>
-        public AmountObj Total { get; init; } = new(0m);
+        public AmountObj Total { get; init; } = new(0m, AssetIdObj.System);
         #endregion
 
         /// <summary>

--- a/HouseholdAccountBook/Models/ValueObjects/AmountObj.cs
+++ b/HouseholdAccountBook/Models/ValueObjects/AmountObj.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using HouseholdAccountBook.Models.AppServices;
+using HouseholdAccountBook.Models.UiDto;
+using System;
 using System.Diagnostics;
 
 namespace HouseholdAccountBook.Models.ValueObjects
@@ -6,7 +8,7 @@ namespace HouseholdAccountBook.Models.ValueObjects
     /// <summary>
     /// 金額VO
     /// </summary>
-    [DebuggerDisplay("{Value:Scale}")]
+    [DebuggerDisplay("{MainValue}")]
     public struct AmountObj
     {
         /// <summary>
@@ -14,9 +16,15 @@ namespace HouseholdAccountBook.Models.ValueObjects
         /// </summary>
         public decimal MainValue { get; set; }
         /// <summary>
+        /// アセットID
+        /// </summary>
+        /// <remarks>初期化以降の書換は不可</remarks>
+        public AssetIdObj AssetId { get; init; }
+
+        /// <summary>
         /// 小数点以下桁数
         /// </summary>
-        public int Scale { get; set; }
+        public readonly int Scale => AssetService.Instance.GetAssetModel(this.AssetId).Scale;
         /// <summary>
         /// 金額(補助単位)
         /// </summary>
@@ -26,29 +34,33 @@ namespace HouseholdAccountBook.Models.ValueObjects
         /// コンストラクタ
         /// </summary>
         /// <param name="mainValue">金額(主単位)</param>
-        public AmountObj(decimal mainValue)
+        /// <param name="assetId">アセットID</param>
+        public AmountObj(decimal mainValue, AssetIdObj assetId)
         {
             this.MainValue = mainValue;
-            this.Scale = 0;
+            this.AssetId = assetId;
         }
         /// <summary>
         /// コンストラクタ
         /// </summary>
         /// <param name="mainValue">金額(主単位)</param>
-        /// <param name="scale">小数点以下桁数</param>
-        public AmountObj(decimal mainValue, int scale)
+        public AmountObj(decimal mainValue)
         {
             this.MainValue = mainValue;
-            this.Scale = scale;
+            this.AssetId = AssetIdObj.System;
         }
 
         /// <summary>
         /// 金額(補助単位)から生成する
         /// </summary>
         /// <param name="subValue">金額(補助単位)</param>
-        /// <param name="scale">小数点以下桁数</param>
+        /// <param name="assetId">アセットID</param>
         /// <returns></returns>
-        public static AmountObj FromSubValue(int subValue, int scale) => new(subValue / (decimal)Math.Pow(10, scale), scale);
+        public static AmountObj FromSubValue(int subValue, AssetIdObj assetId)
+        {
+            AssetModel asset = AssetService.Instance.GetAssetModel(assetId);
+            return new(subValue / (decimal)Math.Pow(10, asset.Scale), assetId);
+        }
 
         // 単項演算子
         public static AmountObj operator +(AmountObj value) => value;
@@ -56,67 +68,66 @@ namespace HouseholdAccountBook.Models.ValueObjects
         public static AmountObj operator -(AmountObj value) => value with { MainValue = -value.MainValue };
 
         // 加算・減算
-        public static AmountObj operator +(AmountObj left, AmountObj right) => new(left.MainValue + right.MainValue, Math.Max(left.Scale, right.Scale));
+        public static AmountObj operator +(AmountObj left, AmountObj right) =>
+            left.AssetId != right.AssetId ? throw new InvalidOperationException() : new(left.MainValue + right.MainValue, left.AssetId);
 
-        public static AmountObj operator -(AmountObj left, AmountObj right) => new(left.MainValue - right.MainValue, Math.Max(left.Scale, right.Scale));
+        public static AmountObj operator -(AmountObj left, AmountObj right) =>
+            left.AssetId != right.AssetId ? throw new InvalidOperationException() : new(left.MainValue - right.MainValue, left.AssetId);
 
         // 乗算
-        public static AmountObj operator *(AmountObj left, AmountObj right) => new(left.MainValue * right.MainValue, left.Scale + right.Scale);
-
-        public static AmountObj operator *(AmountObj left, decimal right) => new(left.MainValue * right, left.Scale);
-
-        public static AmountObj operator *(decimal left, AmountObj right) => new(left * right.MainValue, right.Scale);
+        public static AmountObj operator *(AmountObj left, AmountObj right) => throw new InvalidOperationException();
+        public static AmountObj operator *(AmountObj left, decimal right) => new(left.MainValue * right, left.AssetId);
+        public static AmountObj operator *(decimal left, AmountObj right) => new(left * right.MainValue, right.AssetId);
 
         // 除算
-        public static AmountObj operator /(AmountObj left, AmountObj right) => new(left.MainValue / right.MainValue, left.Scale);
-
-        public static AmountObj operator /(AmountObj left, decimal right) => new(left.MainValue / right, left.Scale);
+        public static AmountObj operator /(AmountObj left, AmountObj right) => throw new InvalidOperationException();
+        public static AmountObj operator /(AmountObj left, decimal right) => new(left.MainValue / right, left.AssetId);
+        public static AmountObj operator /(decimal left, AmountObj right) => throw new InvalidOperationException();
 
         // 剰余
-        public static AmountObj operator %(AmountObj left, AmountObj right) => new(left.MainValue % right.MainValue, Math.Max(left.Scale, right.Scale));
+        public static AmountObj operator %(AmountObj left, AmountObj right) => throw new InvalidOperationException();
+        public static AmountObj operator %(AmountObj left, decimal right) => new(left.MainValue % right, left.AssetId);
 
         // インクリメント・デクリメント
-        public static AmountObj operator ++(AmountObj value) => new(value.MainValue + 1, value.Scale);
-
-        public static AmountObj operator --(AmountObj value) => new(value.MainValue - 1, value.Scale);
+        public static AmountObj operator ++(AmountObj value) => new(value.MainValue + 1, value.AssetId);
+        public static AmountObj operator --(AmountObj value) => new(value.MainValue - 1, value.AssetId);
 
         // 比較演算子
-        public static bool operator ==(AmountObj left, AmountObj right) => left.MainValue == right.MainValue;
+        public static bool operator ==(AmountObj left, AmountObj right) => left.AssetId == right.AssetId && left.MainValue == right.MainValue;
 
-        public static bool operator !=(AmountObj left, AmountObj right) => left.MainValue != right.MainValue;
+        public static bool operator !=(AmountObj left, AmountObj right) => left.AssetId != right.AssetId || left.MainValue != right.MainValue;
 
-        public static bool operator <(AmountObj left, AmountObj right) => left.MainValue < right.MainValue;
+        public static bool operator <(AmountObj left, AmountObj right) => left.AssetId != right.AssetId ? throw new InvalidOperationException() : left.MainValue < right.MainValue;
         public static bool operator <(AmountObj left, decimal right) => left.MainValue < right;
         public static bool operator <(decimal left, AmountObj right) => left < right.MainValue;
 
-        public static bool operator <=(AmountObj left, AmountObj right) => left.MainValue <= right.MainValue;
+        public static bool operator <=(AmountObj left, AmountObj right) => left.AssetId != right.AssetId ? throw new InvalidOperationException() : left.MainValue <= right.MainValue;
         public static bool operator <=(AmountObj left, decimal right) => left.MainValue <= right;
         public static bool operator <=(decimal left, AmountObj right) => left <= right.MainValue;
 
-        public static bool operator >(AmountObj left, AmountObj right) => left.MainValue > right.MainValue;
+        public static bool operator >(AmountObj left, AmountObj right) => left.AssetId != right.AssetId ? throw new InvalidOperationException() : left.MainValue > right.MainValue;
         public static bool operator >(decimal left, AmountObj right) => left > right.MainValue;
         public static bool operator >(AmountObj left, decimal right) => left.MainValue > right;
 
-        public static bool operator >=(AmountObj left, AmountObj right) => left.MainValue >= right.MainValue;
+        public static bool operator >=(AmountObj left, AmountObj right) => left.AssetId != right.AssetId ? throw new InvalidOperationException() : left.MainValue >= right.MainValue;
         public static bool operator >=(AmountObj left, decimal right) => left.MainValue >= right;
         public static bool operator >=(decimal left, AmountObj right) => left >= right.MainValue;
 
         // 暗黙・明示変換
         public static explicit operator decimal(AmountObj value) => value.MainValue;
+        public static explicit operator AmountObj(decimal value) => new(value, AssetIdObj.System);
 
-        public static explicit operator AmountObj(decimal value) => new(value);
-
-        public override readonly string ToString() => this.MainValue.ToString($"F{this.Scale}");
+        public override readonly string ToString() => $"MainValue:{this.MainValue} AssetId:{this.AssetId}";
 
         public override readonly bool Equals(object obj)
         {
             bool ret = false;
             if (obj is AmountObj value) {
-                ret = this.MainValue == value.MainValue && this.Scale == value.Scale;
+                ret = this.MainValue == value.MainValue && this.AssetId == value.AssetId;
             }
             return ret;
         }
 
-        public override readonly int GetHashCode() => HashCode.Combine(this.MainValue, this.Scale);
+        public override readonly int GetHashCode() => HashCode.Combine(this.MainValue, this.AssetId);
     }
 }

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -7,9 +7,16 @@
 ### 2026-07-19
 
 - 全般
-   - ↑NumericUpDownに小数が指定されたときに四捨五入が発生するのを修正した - refs #214
-   - ↑NumericUpDownにnullが指定されたときにScaleが適用されなかったのを修正した - refs #214
-   - ↑NumericUpDownのScaleがデフォルトで双方向になっていたのを修正した - refs #214 
+   - ↑NumericUpDownに小数が指定されたときに四捨五入が発生するのを修正した - refs #223
+   - ↑NumericUpDownにnullが指定されたときにScaleが適用されなかったのを修正した - refs #223
+   - ↑NumericUpDownのScaleがデフォルトで双方向になっていたのを修正した - refs #223
+   - △帳簿ごとに設定されたアセットに応じた金額が表示されるように変更した - refs #214 
+
+- MoveRegistrationWindow
+   - △移動元と移動先の帳簿のアセットが異なる場合に、移動元と移動先それぞれの金額を入力可能に変更した - refs #214
+
+- SettingWindow
+   - △帳簿ごとにアセットを設定可能に変更した - refs #214
 
 ### 2026-07-16
 

--- a/HouseholdAccountBook/ViewModels/Component/DateValueViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Component/DateValueViewModel.cs
@@ -20,14 +20,30 @@ namespace HouseholdAccountBook.ViewModels.Component
         public ActionIdObj ActionId { get; set; }
 
         /// <summary>
-        /// 日付
+        /// 選択された日付
         /// </summary>
-        public DateTime ActDate { get; set; }
+        public DateTime SelectedDate { get; set; }
 
         /// <summary>
-        /// 金額(主単位)
+        /// 選択されたアセットID
         /// </summary>
-        public decimal? ActValue {
+        public AssetIdObj SelectedAssetId => this.SelectedAccountAssetId; //TODO: 帳簿項目のアセットIDがSystemでなければ帳簿のアセットIDを採用する
+        /// <summary>
+        /// 選択された帳簿のアセットID
+        /// </summary>
+        public AssetIdObj SelectedAccountAssetId {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    this.RaisePropertyChanged(nameof(this.InputedValueStr));
+                    this.RaisePropertyChanged(nameof(this.ValueScale));
+                }
+            }
+        }
+        /// <summary>
+        /// 入力された金額(主単位)
+        /// </summary>
+        public decimal? InputedValue {
             get;
             set {
                 if (this.SetProperty(ref field, value)) {
@@ -36,16 +52,13 @@ namespace HouseholdAccountBook.ViewModels.Component
             }
         }
         /// <summary>
-        /// 金額(文字列)
+        /// 入力された金額(文字列)
         /// </summary>
-        public string ActValueStr => AssetService.Instance.ToAssetString(this.ActValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string InputedValueStr => AssetService.Instance.ToAssetString(this.InputedValue, this.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
         /// <summary>
-        /// 小数点以下桁数
+        /// 金額の小数点以下桁数
         /// </summary>
-        public int Scale {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
+        public int ValueScale => AssetService.Instance.GetAssetModel(this.SelectedAssetId).Scale;
 
         /// <summary>
         /// <see cref="NumericUpDown"/> の編集状態

--- a/HouseholdAccountBook/ViewModels/Loaders/SeriesViewModelLoader.cs
+++ b/HouseholdAccountBook/ViewModels/Loaders/SeriesViewModelLoader.cs
@@ -78,7 +78,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                     Values = [value],
                     Periods = [tmpPeriod],
                     Total = value,
-                    Average = period.End < DateOnlyExtensions.Today ? value : new(0m) // 平均値は過去のデータのみで計算する
+                    Average = period.End < DateOnlyExtensions.Today ? value : new(0m, value.AssetId) // 平均値は過去のデータのみで計算する
                 };
                 vmList.Add(vm);
             }
@@ -121,7 +121,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                         vm.Average /= averageCount;
                     }
                     else {
-                        vm.Average = new(0m);
+                        vm.Average = new(0m, vm.Average.Value.AssetId);
                     }
                 }
             }
@@ -176,7 +176,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                     Values = [value],
                     Periods = [tmpPeriod],
                     Total = value,
-                    Average = tmpPeriod.End.IsPost() ? value : new(0m)
+                    Average = tmpPeriod.End.IsPost() ? value : new(0m, value.AssetId)
                 };
                 vmList.Add(vm);
             }
@@ -219,7 +219,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                         vm.Average /= averageCount;
                     }
                     else {
-                        vm.Average = new(0m);
+                        vm.Average = new(0m, vm.Average.Value.AssetId);
                     }
                 }
             }
@@ -267,7 +267,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                     Values = [],
                     Periods = [],
                     Total = value,
-                    Average = tmpPeriod.End.IsPost() ? value : new(0m)
+                    Average = tmpPeriod.End.IsPost() ? value : new(0m, value.AssetId)
                 };
                 vm.Values.Add(value);
                 vm.Periods.Add(tmpPeriod);
@@ -313,7 +313,7 @@ namespace HouseholdAccountBook.ViewModels.Loaders
                         vm.Average /= averageCount;
                     }
                     else {
-                        vm.Average = new(0m);
+                        vm.Average = new(0m, vm.Average.Value.AssetId);
                     }
                 }
             }

--- a/HouseholdAccountBook/ViewModels/Windows/ActionListRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/ActionListRegistrationWindowViewModel.cs
@@ -39,19 +39,19 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 帳簿変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<AccountIdObj>> AccountChanged;
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedAccountChanged;
         /// <summary>
         /// 収支変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<BalanceKind>> BalanceKindChanged;
+        public event EventHandler<ChangedEventArgs<BalanceKind>> SelectedBalanceKindChanged;
         /// <summary>
         /// 分類変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<CategoryIdObj>> CategoryChanged;
+        public event EventHandler<ChangedEventArgs<CategoryIdObj>> SelectedCategoryChanged;
         /// <summary>
         /// 項目変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<ItemIdObj>> ItemChanged;
+        public event EventHandler<ChangedEventArgs<ItemIdObj>> SelectedItemChanged;
 
         /// <summary>
         /// 登録時イベント
@@ -151,7 +151,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public new ICommand OKCommand => field ??= new AsyncRelayCommand(
             this.OKCommand_ExecuteAsync,
-            () => this.ItemSelectorVM.SelectedKey != null && this.InputedDateValueVMList.Any(static vm => vm.ActValue is not null and not 0), this.mBusyService);
+            () => this.ItemSelectorVM.SelectedKey != null && this.InputedDateValueVMList.Any(static vm => vm.InputedValue is not null and not 0), this.mBusyService);
         protected async Task OKCommand_ExecuteAsync()
         {
             // DB登録
@@ -214,8 +214,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
             using FuncLog funcLog = new(new { initialAccountId, initialMonth, initialDate, initialRecordList, targetGroupId });
             using IDisposable disposable = this.mBusyService.Enter();
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
-
             AccountIdObj selectingAccountId = null;
             BalanceKind selectingBalanceKind = BalanceKind.Expenses;
             ItemIdObj selectingItemId = null;
@@ -229,11 +227,18 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     // WVMに値を設定する
                     if (initialRecordList == null) {
                         DateTime actDate = initialDate?.ToDateTime(TimeOnly.MinValue) ?? ((initialMonth == null || initialMonth?.Month == DateTime.Today.Month) ? DateTime.Today : initialMonth.Value.ToDateTime(TimeOnly.MinValue));
-                        this.InputedDateValueVMList.Add(new DateValueViewModel() { ActDate = actDate, ActValue = null, Scale = asset.Scale });
+                        this.InputedDateValueVMList.Add(new DateValueViewModel() {
+                            SelectedDate = actDate,
+                            InputedValue = null
+                        });
                     }
                     else {
                         foreach (ActionCsvModel record in initialRecordList) {
-                            this.InputedDateValueVMList.Add(new DateValueViewModel() { ActDate = record.Date, ActValue = record.Value.MainValue, Scale = record.Value.Scale });
+                            this.InputedDateValueVMList.Add(new DateValueViewModel() {
+                                SelectedDate = record.Date,
+                                InputedValue = record.Value.MainValue,
+                                SelectedAccountAssetId = record.Value.AssetId // 一旦読込時のアセットIDを入れておく
+                            });
                         }
                     }
 
@@ -249,9 +254,9 @@ namespace HouseholdAccountBook.ViewModels.Windows
                         // 日付金額リストに追加
                         DateValueViewModel vm = new() {
                             ActionId = action.ActionId,
-                            ActDate = action.ActTime,
-                            ActValue = Math.Abs(action.Amount.MainValue),
-                            Scale = asset.Scale
+                            SelectedDate = action.ActTime,
+                            InputedValue = Math.Abs(action.Amount.MainValue),
+                            SelectedAccountAssetId = action.Amount.AssetId // 一旦読込時のアセットIDを入れておく
                         };
 
                         selectingAccountId = action.Account.Id;
@@ -283,22 +288,37 @@ namespace HouseholdAccountBook.ViewModels.Windows
             await this.ItemSelectorVM.LoadAsync(selectingItemId);
             await this.ShopSelectorVM.LoadAsync(selectingShopName);
             await this.RemarkSelectorVM.LoadAsync(selectingRemark);
+
+            // アセットIDを指定する
+            foreach (DateValueViewModel item in this.InputedDateValueVMList) {
+                item.SelectedAccountAssetId = this.AccountSelectorVM.SelectedItem.AssetId;
+            }
         }
 
         public override void AddEventHandlers()
         {
             using FuncLog funcLog = new();
 
-            this.AccountSelectorVM.SelectionChanged += (sender, e) => this.AccountChanged?.Invoke(sender, e);
+            // 帳簿変更時
+            this.AccountSelectorVM.SelectionChanged += (sender, e) => {
+                foreach (DateValueViewModel item in this.InputedDateValueVMList) {
+                    item.SelectedAccountAssetId = this.AccountSelectorVM.SelectedItem.AssetId;
+                }
+
+                this.SelectedAccountChanged?.Invoke(sender, e);
+            };
             this.AccountSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
 
-            this.BalanceKindSelectorVM.SelectionChanged += (sender, e) => this.BalanceKindChanged?.Invoke(sender, e);
+            // 収支種別変更時
+            this.BalanceKindSelectorVM.SelectionChanged += (sender, e) => this.SelectedBalanceKindChanged?.Invoke(sender, e);
             this.BalanceKindSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
 
-            this.CategorySelectorVM.SelectionChanged += (sender, e) => this.CategoryChanged?.Invoke(sender, e);
+            // 分類変更時
+            this.CategorySelectorVM.SelectionChanged += (sender, e) => this.SelectedCategoryChanged?.Invoke(sender, e);
             this.CategorySelectorVM.Children.Add(this.ItemSelectorVM);
 
-            this.ItemSelectorVM.SelectionChanged += (sender, e) => this.ItemChanged?.Invoke(sender, e);
+            // 項目変更時
+            this.ItemSelectorVM.SelectionChanged += (sender, e) => this.SelectedItemChanged?.Invoke(sender, e);
             this.ItemSelectorVM.Children.AddRange([this.ShopSelectorVM, this.RemarkSelectorVM]);
         }
 
@@ -313,7 +333,8 @@ namespace HouseholdAccountBook.ViewModels.Windows
             List<ActionModel> actionList = [];
             BalanceKind balanceKind = this.BalanceKindSelectorVM.SelectedKey;
             ActionModel commonAction = new() {
-                Base = new(null, DateTime.Now, new(0m)),
+                Base = new(null, DateTime.Now, new(0m, AssetIdObj.System)),
+                AssetId = AssetIdObj.System, // TODO: 将来の拡張用
                 GroupId = this.GroupId,
                 Account = new(this.AccountSelectorVM.SelectedKey, string.Empty),
                 Item = new(this.ItemSelectorVM.SelectedKey, string.Empty),
@@ -321,15 +342,16 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 Remark = this.RemarkSelectorVM.SelectedKey
             };
             foreach (DateValueViewModel vm in this.InputedDateValueVMList) {
-                if (vm.ActValue is null or 0) { continue; }
+                if (vm.InputedValue is null or 0) { continue; }
 
-                ActionBaseModel baseAction = new(vm.ActionId, vm.ActDate, new((balanceKind == BalanceKind.Income ? 1 : -1) * vm.ActValue.Value, vm.Scale));
+                int sign = balanceKind == BalanceKind.Income ? 1 : -1;
+                ActionBaseModel baseAction = new(vm.ActionId, vm.SelectedDate, new(sign * vm.InputedValue.Value, AssetIdObj.System));
                 actionList.Add(commonAction.WithChanges(baseAction));
             }
 
             IEnumerable<ActionIdObj> resActionIdList = await this.mService.SaveActionListAsync(actionList);
 
-            DateTime lastActTime = this.InputedDateValueVMList.Max(static tmp => tmp.ActDate);
+            DateTime lastActTime = this.InputedDateValueVMList.Max(static tmp => tmp.SelectedDate);
 
             if (!string.IsNullOrEmpty(commonAction.Shop)) {
                 ShopModel shop = new(commonAction.Shop) { ItemId = commonAction.Item.Id, CurrentActTime = commonAction.ActTime };

--- a/HouseholdAccountBook/ViewModels/Windows/ActionRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/ActionRegistrationWindowViewModel.cs
@@ -35,23 +35,23 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 帳簿変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<AccountIdObj>> AccountChanged;
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedAccountChanged;
         /// <summary>
         /// 日時変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<DateTime>> DateChanged;
+        public event EventHandler<ChangedEventArgs<DateTime>> SelectedDateChanged;
         /// <summary>
         /// 収支変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<BalanceKind>> BalanceKindChanged;
+        public event EventHandler<ChangedEventArgs<BalanceKind>> SelectedBalanceKindChanged;
         /// <summary>
         /// 分類変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<CategoryIdObj>> CategoryChanged;
+        public event EventHandler<ChangedEventArgs<CategoryIdObj>> SelectedCategoryChanged;
         /// <summary>
         /// 項目変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<ItemIdObj>> ItemChanged;
+        public event EventHandler<ChangedEventArgs<ItemIdObj>> SelectedItemChanged;
 
         /// <summary>
         /// 登録時イベント
@@ -104,7 +104,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
             set {
                 DateTime oldValue = field;
                 if (this.SetProperty(ref field, value)) {
-                    this.DateChanged?.Invoke(this, new() { OldValue = oldValue, NewValue = value });
+                    this.SelectedDateChanged?.Invoke(this, new() { OldValue = oldValue, NewValue = value });
                     CommandManager.InvalidateRequerySuggested();
                 }
             }
@@ -126,6 +126,18 @@ namespace HouseholdAccountBook.ViewModels.Windows
         public SelectorViewModel<ItemModel, ItemIdObj> ItemSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
 
         /// <summary>
+        /// 選択されたアセットID
+        /// </summary>
+        public AssetIdObj SelectedAssetId {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    this.RaisePropertyChanged(nameof(this.ValueScale));
+                    this.RaisePropertyChanged(nameof(this.InputedValueStr));
+                }
+            }
+        } = AssetIdObj.System;
+        /// <summary>
         /// 入力された金額(主単位)
         /// </summary>
         public decimal? InputedValue {
@@ -140,14 +152,11 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 金額の小数点以下桁数
         /// </summary>
-        public int ValueScale {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
+        public int ValueScale => AssetService.Instance.GetAssetModel(this.SelectedAssetId).Scale;
         /// <summary>
         /// 入力された金額(文字列)
         /// </summary>
-        public string InputedValueStr => AssetService.Instance.ToAssetString(this.InputedValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string InputedValueStr => AssetService.Instance.ToAssetString(this.InputedValue, this.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
 
         /// <summary>
         /// 店舗セレクタVM
@@ -292,8 +301,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
             using FuncLog funcLog = new(new { initialAccountId, initialMonth, initialDate, initialRecord, targetActionId });
             using IDisposable disposable = this.mBusyService.Enter();
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
-
             AccountIdObj selectingAccountId = null;
             BalanceKind selectingBalanceKind = BalanceKind.Expenses;
             ItemIdObj selectingItemId = null;
@@ -307,12 +314,10 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     if (initialRecord == null) {
                         this.SelectedDate = initialDate?.ToDateTime(TimeOnly.MinValue) ?? ((initialMonth == null || initialMonth?.Month == DateTime.Today.Month) ? DateTime.Today : initialMonth.Value.ToDateTime(TimeOnly.MinValue));
                         this.InputedValue = null;
-                        this.ValueScale = asset.Scale;
                     }
                     else {
                         this.SelectedDate = initialRecord.Date;
                         this.InputedValue = initialRecord.Value.MainValue;
-                        this.ValueScale = initialRecord.Value.Scale;
                     }
 
                     break;
@@ -332,7 +337,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     }
                     this.SelectedDate = action.ActTime;
                     this.InputedValue = Math.Abs(action.Amount.MainValue);
-                    this.ValueScale = action.Amount.Scale;
                     this.InputedCount = count;
 
                     selectingAccountId = action.Account.Id;
@@ -353,22 +357,33 @@ namespace HouseholdAccountBook.ViewModels.Windows
             await this.ShopSelectorVM.LoadAsync(selectingShopName);
             await this.RemarkSelectorVM.LoadAsync(selectingRemark);
             await this.HolidaySettingSelectorVM.LoadAsync(HolidaySettingKind.Nothing);
+
+            // アセットIDを指定する
+            this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
         }
 
         public override void AddEventHandlers()
         {
             using FuncLog funcLog = new();
 
-            this.AccountSelectorVM.SelectionChanged += (sender, e) => this.AccountChanged?.Invoke(sender, e);
+            // 帳簿選択変更時
+            this.AccountSelectorVM.SelectionChanged += (sender, e) => {
+                this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+
+                this.SelectedAccountChanged?.Invoke(sender, e);
+            };
             this.AccountSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
 
-            this.BalanceKindSelectorVM.SelectionChanged += (sender, e) => this.BalanceKindChanged?.Invoke(sender, e);
+            // 収支種別選択変更時
+            this.BalanceKindSelectorVM.SelectionChanged += (sender, e) => this.SelectedBalanceKindChanged?.Invoke(sender, e);
             this.BalanceKindSelectorVM.Children.AddRange([this.CategorySelectorVM, this.ItemSelectorVM]);
 
-            this.CategorySelectorVM.SelectionChanged += (sender, e) => this.CategoryChanged?.Invoke(sender, e);
+            // 分類選択変更時
+            this.CategorySelectorVM.SelectionChanged += (sender, e) => this.SelectedCategoryChanged?.Invoke(sender, e);
             this.CategorySelectorVM.Children.Add(this.ItemSelectorVM);
 
-            this.ItemSelectorVM.SelectionChanged += (sender, e) => this.ItemChanged?.Invoke(sender, e);
+            // 項目選択変更時
+            this.ItemSelectorVM.SelectionChanged += (sender, e) => this.SelectedItemChanged?.Invoke(sender, e);
             this.ItemSelectorVM.Children.AddRange([this.ShopSelectorVM, this.RemarkSelectorVM]);
         }
 
@@ -380,8 +395,10 @@ namespace HouseholdAccountBook.ViewModels.Windows
         {
             using FuncLog funcLog = new();
 
+            int sign = this.BalanceKindSelectorVM.SelectedKey == BalanceKind.Income ? 1 : -1;
             ActionModel action = new() {
-                Base = new(this.ActionId, this.SelectedDate, new((this.BalanceKindSelectorVM.SelectedKey == BalanceKind.Income ? 1 : -1) * this.InputedValue.Value, this.ValueScale)),
+                Base = new(this.ActionId, this.SelectedDate, new(sign * this.InputedValue.Value, this.AccountSelectorVM.SelectedItem.AssetId)),
+                AssetId = AssetIdObj.System, // TODO: 将来の拡張用
                 GroupId = this.GroupId,
                 Account = new(this.AccountSelectorVM.SelectedKey, string.Empty),
                 Category = new(CategoryIdObj.System, string.Empty, this.BalanceKindSelectorVM.SelectedKey),

--- a/HouseholdAccountBook/ViewModels/Windows/CsvComparisonWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/CsvComparisonWindowViewModel.cs
@@ -87,6 +87,19 @@ namespace HouseholdAccountBook.ViewModels.Windows
         public SelectorViewModel<AccountModel, AccountIdObj> AccountSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
 
         /// <summary>
+        /// 選択されたアセットID
+        /// </summary>
+        public AssetIdObj SelectedAssetId {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    this.RaisePropertyChanged(nameof(this.AllSumValueStr));
+                    this.RaisePropertyChanged(nameof(this.SelectedSumValueStr));
+                }
+            }
+        }
+
+        /// <summary>
         /// CSV比較セレクタVM
         /// </summary>
         public SelectorViewModel<CsvComparisonViewModel> CsvCompSelectorVM => field ??= new(this.mBusyService);
@@ -101,7 +114,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// CSV比較VMの合計値(文字列)
         /// </summary>
-        public string AllSumValueStr => AssetService.Instance.ToAssetString(this.AllSumValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string AllSumValueStr => AssetService.Instance.ToAssetString(this.AllSumValue, this.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
 
         /// <summary>
         /// 選択されたCSV比較VMのチェック数
@@ -114,7 +127,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 選択されたCSV比較VMの合計値(文字列)
         /// </summary>
-        public string SelectedSumValueStr => AssetService.Instance.ToAssetString(this.SelectedSumValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string SelectedSumValueStr => AssetService.Instance.ToAssetString(this.SelectedSumValue, this.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
 
         /// <summary>
         /// チェック数変更を通知する
@@ -461,6 +474,9 @@ namespace HouseholdAccountBook.ViewModels.Windows
             await this.AccountSelectorVM.LoadAsync(initialAccountId);
             // 初回のウィンドウのオープン時に選択された帳簿を通知する
             this.AccountChanged?.Invoke(this, new() { OldValue = null, NewValue = this.AccountSelectorVM.SelectedKey });
+
+            // アセットを設定する
+            this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
         }
 
         public override void AddEventHandlers()
@@ -475,6 +491,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
             this.AccountSelectorVM.SelectionChanged += async (sender, e) => {
                 this.AccountChanged?.Invoke(sender, e);
 
+                this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
                 await this.ReloadCsvFilesAsync();
                 await this.UpdateComparisonVMListAsync(true);
             };
@@ -525,8 +542,9 @@ namespace HouseholdAccountBook.ViewModels.Windows
             int expensesIndex = this.AccountSelectorVM.SelectedItem.ExpensesIndex.Value;
 
             // CSVファイルを読み込む
+            Encoding encoding = Encoding.GetEncoding(this.AccountSelectorVM.SelectedItem.TextEncoding);
             List<ActionCsvModel> tmpVMList = [..
-                await this.mService.LoadCsvCompListAsync(csvFilePathList, actDateIndex, itemNameIndex, expensesIndex, Encoding.GetEncoding(this.AccountSelectorVM.SelectedItem.TextEncoding))];
+                await this.mService.LoadCsvCompListAsync(this.SelectedAssetId, csvFilePathList, actDateIndex, itemNameIndex, expensesIndex, encoding)];
 
             // 有効な行があればリストに追加する(日付昇順)
             if (0 < tmpVMList.Count) {
@@ -569,7 +587,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
                 foreach (ActionModel action in actionList) {
                     // 帳簿項目IDが使用済なら次のレコードを調べるようにする
-                    bool checkNext = this.CsvCompSelectorVM.ItemList.Where(tmpVM => (int?)tmpVM.Action?.ActionId == action.ActionId).Any();
+                    bool checkNext = this.CsvCompSelectorVM.ItemList.Any(tmpVM => (int?)tmpVM.Action?.ActionId == action.ActionId);
                     // 帳簿項目情報を紐付ける
                     if (!checkNext) {
                         vm.Action = action;

--- a/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
@@ -54,6 +54,10 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedAccountChanged;
         /// <summary>
+        /// 選択アセット変更時イベント
+        /// </summary>
+        public event EventHandler<ChangedEventArgs<AssetIdObj>> SelectedAssetChanged;
+        /// <summary>
         /// タブ選択変更時イベント
         /// </summary>
         public event EventHandler<ChangedEventArgs<Tabs>> SelectedTabChanged;
@@ -233,6 +237,19 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// 帳簿セレクタVM
         /// </summary>
         public SelectorViewModel<AccountModel, AccountIdObj> AccountSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
+
+        /// <summary>
+        /// 選択されたアセットID
+        /// </summary>
+        public AssetIdObj SelectedAssetId {
+            get;
+            private set {
+                AssetIdObj old = field;
+                if (this.SetProperty(ref field, value)) {
+                    this.SelectedAssetChanged?.Invoke(this, new() { OldValue = old, NewValue = value });
+                }
+            }
+        } = AssetIdObj.System;
 
         /// <summary>
         /// 選択された収支種別
@@ -1135,10 +1152,44 @@ namespace HouseholdAccountBook.ViewModels.Windows
             this.GraphKind2SelectorVM.SetLoader(() => GraphKind2Str);
         }
 
+        public override async Task LoadAsync()
+        {
+            using FuncLog funcLog = new();
+            using IDisposable disposable = this.mBusyService.Enter();
+
+            this.FiscalStartMonth = UserSettingService.Instance.FiscalStartMonth;
+
+            this.SelectedDBKind = this.mDbHandlerFactory.DBKind;
+
+            // 帳簿リスト更新
+            await this.AccountSelectorVM.LoadAsync(UserSettingService.Instance.SelectedAccountId);
+            // タブ選択
+            this.SelectedTab = UserSettingService.Instance.SelectedTab;
+            // グラフ種別1更新
+            await this.GraphKind1SelectorVM.LoadAsync(UserSettingService.Instance.SelectedGraphKind1);
+            // グラフ種別2更新
+            await this.GraphKind2SelectorVM.LoadAsync(UserSettingService.Instance.SelectedGraphKind2);
+
+            Log.Vars(vars: new { this.SelectedTabIndex, this.SelectedGraphKind1Index, this.SelectedGraphKind2Index });
+
+            this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+
+            await this.UpdateAsync(isUpdateAccountList: false, isScroll: true, isUpdateActDateLastEdited: true);
+        }
+
         public override void AddEventHandlers()
         {
             using FuncLog funcLog = new();
 
+            // 帳簿選択変更時
+            this.AccountSelectorVM.SelectionChanged += async (sender, e) => {
+                this.SelectedAccountChanged?.Invoke(sender, e);
+
+                this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+                UserSettingService.Instance.SelectedAccountId = e.NewValue ?? AccountIdObj.System;
+
+                await this.UpdateAsync(isUpdateAccountList: false, isScroll: true);
+            };
             // タブ選択変更時
             this.SelectedTabChanged += async (sender, e) => {
                 using FuncLog funcLog = new(new { e.OldValue, e.NewValue }, methodName: nameof(this.SelectedTabChanged));
@@ -1147,14 +1198,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 UserSettingService.Instance.SelectedTab = e.NewValue;
 
                 await this.UpdateAsync(isUpdateAccountList: true, isScroll: true);
-            };
-            // 帳簿選択変更時
-            this.AccountSelectorVM.SelectionChanged += async (sender, e) => {
-                this.SelectedAccountChanged?.Invoke(sender, e);
-
-                UserSettingService.Instance.SelectedAccountId = e.NewValue ?? AccountIdObj.System;
-
-                await this.UpdateAsync(isUpdateAccountList: false, isScroll: true);
             };
             // グラフ種別1選択変更時
             this.GraphKind1SelectorVM.SelectionChanged += async (sender, e) => {
@@ -1187,29 +1230,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 childVM.SaveFileDialogRequested += (sender, e) => this.SaveFileDialogRequest(e);
                 childVM.AddEventHandlers();
             });
-        }
-
-        public override async Task LoadAsync()
-        {
-            using FuncLog funcLog = new();
-            using IDisposable disposable = this.mBusyService.Enter();
-
-            this.FiscalStartMonth = UserSettingService.Instance.FiscalStartMonth;
-
-            this.SelectedDBKind = this.mDbHandlerFactory.DBKind;
-
-            // 帳簿リスト更新
-            await this.AccountSelectorVM.LoadAsync(UserSettingService.Instance.SelectedAccountId);
-            // タブ選択
-            this.SelectedTab = UserSettingService.Instance.SelectedTab;
-            // グラフ種別1更新
-            await this.GraphKind1SelectorVM.LoadAsync(UserSettingService.Instance.SelectedGraphKind1);
-            // グラフ種別2更新
-            await this.GraphKind2SelectorVM.LoadAsync(UserSettingService.Instance.SelectedGraphKind2);
-
-            Log.Vars(vars: new { this.SelectedTabIndex, this.SelectedGraphKind1Index, this.SelectedGraphKind2Index });
-
-            await this.UpdateAsync(isUpdateAccountList: false, isScroll: true, isUpdateActDateLastEdited: true);
         }
 
         #region ウィンドウ設定プロパティ

--- a/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MoveRegistrationWindowViewModel.cs
@@ -36,19 +36,19 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 移動元帳簿変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<AccountIdObj>> FromAccountChanged;
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedFromAccountChanged;
         /// <summary>
         /// 移動先帳簿変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<AccountIdObj>> ToAccountChanged;
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedToAccountChanged;
         /// <summary>
         /// 手数料種別変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<CommissionKind>> CommissionKindChanged;
+        public event EventHandler<ChangedEventArgs<CommissionKind>> SelectedCommissionKindChanged;
         /// <summary>
-        /// 項目変更時イベント
+        /// 手数料項目変更時イベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<ItemIdObj>> ItemChanged;
+        public event EventHandler<ChangedEventArgs<ItemIdObj>> SelectedCommissionItemChanged;
 
         /// <summary>
         /// 登録時イベント
@@ -64,21 +64,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
             get;
             set => this.SetProperty(ref field, value);
         }
-
-        /// <summary>
-        /// 移動元帳簿項目ID
-        /// </summary>
-        public ActionIdObj FromActionId {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
-        /// <summary>
-        /// 移動先帳簿項目ID
-        /// </summary>
-        public ActionIdObj ToActionId {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
         /// <summary>
         /// グループID
         /// </summary>
@@ -87,14 +72,19 @@ namespace HouseholdAccountBook.ViewModels.Windows
             set => this.SetProperty(ref field, value);
         }
 
+        #region 移動元帳簿項目
+        /// <summary>
+        /// 移動元帳簿項目ID
+        /// </summary>
+        public ActionIdObj FromActionId {
+            get;
+            set => this.SetProperty(ref field, value);
+        }
+
         /// <summary>
         /// 移動元帳簿セレクタVM
         /// </summary>
         public SelectorViewModel<AccountModel, AccountIdObj> FromAccountSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
-        /// <summary>
-        /// 移動先帳簿セレクタVM
-        /// </summary>
-        public SelectorViewModel<AccountModel, AccountIdObj> ToAccountSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
 
         /// <summary>
         /// 選択された日付(移動元)
@@ -105,12 +95,74 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 if (this.SetProperty(ref field, value)) {
                     CommandManager.InvalidateRequerySuggested();
 
-                    if (this.SelectedToDate < value || this.IsLink) {
+                    if (this.SelectedToDate < value || this.IsDateLink) {
                         this.SelectedToDate = value;
                     }
                 }
             }
         } = DateTime.Today;
+
+        /// <summary>
+        /// 選択された移動元アセットID
+        /// </summary>
+        public AssetIdObj SelectedFromAssetId => this.SelectedFromAccountAssetId; //TODO: 帳簿項目のアセットIDがSystemでなければ帳簿のアセットIDを採用する
+        /// <summary>
+        /// 選択された移動元帳簿アセットID
+        /// </summary>
+        public AssetIdObj SelectedFromAccountAssetId {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    this.RaisePropertyChanged(nameof(this.IsSameAsset));
+                    this.RaisePropertyChanged(nameof(this.FromValueScale));
+                    this.RaisePropertyChanged(nameof(this.InputedFromValueStr));
+
+                    if (this.IsSameAsset) {
+                        this.InputedToValue = this.InputedFromValue;
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// 入力された移動元金額
+        /// </summary>
+        public decimal? InputedFromValue {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    CommandManager.InvalidateRequerySuggested();
+                    this.RaisePropertyChanged(nameof(this.InputedFromValueStr));
+
+                    if (this.IsSameAsset) {
+                        this.InputedToValue = field;
+                    }
+                }
+            }
+        }
+        /// <summary>
+        /// 移動元金額の小数点以下桁数
+        /// </summary>
+        public int FromValueScale => AssetService.Instance.GetAssetModel(this.SelectedFromAssetId).Scale;
+        /// <summary>
+        /// 入力された移動元金額(文字列)
+        /// </summary>
+        public string InputedFromValueStr => AssetService.Instance.ToAssetString(this.InputedFromValue, this.SelectedFromAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
+        #endregion
+
+        #region 移動先帳簿項目
+        /// <summary>
+        /// 移動先帳簿項目ID
+        /// </summary>
+        public ActionIdObj ToActionId {
+            get;
+            set => this.SetProperty(ref field, value);
+        }
+
+        /// <summary>
+        /// 移動先帳簿セレクタVM
+        /// </summary>
+        public SelectorViewModel<AccountModel, AccountIdObj> ToAccountSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
+
         /// <summary>
         /// 選択された日付(移動先)
         /// </summary>
@@ -122,7 +174,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
                     if (value < this.SelectedFromDate) {
                         this.SelectedFromDate = value;
-                        this.IsLink = true;
+                        this.IsDateLink = true;
                     }
                 }
             }
@@ -130,7 +182,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 移動先日時が移動元日時に連動して編集
         /// </summary>
-        public bool IsLink {
+        public bool IsDateLink {
             get;
             set {
                 if (this.SetProperty(ref field, value)) {
@@ -142,29 +194,51 @@ namespace HouseholdAccountBook.ViewModels.Windows
         } = true;
 
         /// <summary>
-        /// 入力された金額
+        /// 選択された移動先アセットID
         /// </summary>
-        public decimal? InputedValue {
+        public AssetIdObj SelectedToAssetId => this.SelectedToAccountAssetId; //TODO: 帳簿項目のアセットIDがSystemでなければ帳簿のアセットIDを採用する
+        /// <summary>
+        /// 選択された移動先帳簿アセットID
+        /// </summary>
+        public AssetIdObj SelectedToAccountAssetId {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    this.RaisePropertyChanged(nameof(this.IsSameAsset));
+                    this.RaisePropertyChanged(nameof(this.ToValueScale));
+                    this.RaisePropertyChanged(nameof(this.InputedToValueStr));
+
+                    if (this.IsSameAsset) {
+                        this.InputedToValue = this.InputedFromValue;
+                    }
+                }
+            }
+        }
+
+        public bool IsSameAsset => this.SelectedFromAssetId == this.SelectedToAssetId;
+        /// <summary>
+        /// 入力された移動先金額
+        /// </summary>
+        public decimal? InputedToValue {
             get;
             set {
                 if (this.SetProperty(ref field, value)) {
                     CommandManager.InvalidateRequerySuggested();
-                    this.RaisePropertyChanged(nameof(this.InputedValueStr));
+                    this.RaisePropertyChanged(nameof(this.InputedToValueStr));
                 }
             }
         }
         /// <summary>
-        /// 金額の小数点以下桁数
+        /// 移動先金額の小数点以下桁数
         /// </summary>
-        public int ValueScale {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
+        public int ToValueScale => AssetService.Instance.GetAssetModel(this.SelectedToAssetId).Scale;
         /// <summary>
-        /// 入力された金額(文字列)
+        /// 入力された移動先金額(文字列)
         /// </summary>
-        public string InputedValueStr => AssetService.Instance.ToAssetString(this.InputedValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string InputedToValueStr => AssetService.Instance.ToAssetString(this.InputedToValue, this.SelectedToAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
+        #endregion
 
+        #region 手数料帳簿項目
         /// <summary>
         /// 手数料の帳簿項目ID
         /// </summary>
@@ -184,6 +258,22 @@ namespace HouseholdAccountBook.ViewModels.Windows
         public SelectorViewModel<ItemModel, ItemIdObj> ItemSelectorVM => field ??= new(static vm => vm?.Id, this.mBusyService);
 
         /// <summary>
+        /// 選択された手数料アセットID
+        /// </summary>
+        public AssetIdObj SelectedCommissionAssetId => this.SelectedCommissionAccountAssetId; //TODO: 帳簿項目のアセットIDがSystemでなければ帳簿のアセットIDを採用する
+        /// <summary>
+        /// 選択された手数料帳簿アセットID
+        /// </summary>
+        public AssetIdObj SelectedCommissionAccountAssetId {
+            get;
+            set {
+                if (this.SetProperty(ref field, value)) {
+                    this.RaisePropertyChanged(nameof(this.CommissionScale));
+                    this.RaisePropertyChanged(nameof(this.InputedCommissionStr));
+                }
+            }
+        }
+        /// <summary>
         /// 入力された手数料
         /// </summary>
         public decimal? InputedCommission {
@@ -198,19 +288,17 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// <summary>
         /// 手数料の小数点以下桁数
         /// </summary>
-        public int CommissionScale {
-            get;
-            set => this.SetProperty(ref field, value);
-        }
+        public int CommissionScale => AssetService.Instance.GetAssetModel(this.SelectedCommissionAssetId).Scale;
         /// <summary>
         /// 入力された手数料(文字列)
         /// </summary>
-        public string InputedCommissionStr => AssetService.Instance.ToAssetString(this.InputedCommission, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string InputedCommissionStr => AssetService.Instance.ToAssetString(this.InputedCommission, this.SelectedCommissionAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
 
         /// <summary>
         /// 備考セレクタVM
         /// </summary>
         public SelectorViewModel<RemarkModel, string> RemarkSelectorVM => field ??= new(static vm => vm?.Remark, this.mBusyService);
+        #endregion
         #endregion
 
         #region コマンド
@@ -224,7 +312,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
         /// </summary>
         public new ICommand OKCommand => field ??= new AsyncRelayCommand(
             this.OKCommand_ExecuteAsync,
-            () => this.InputedValue is not null && this.FromAccountSelectorVM?.SelectedKey != this.ToAccountSelectorVM?.SelectedKey, this.mBusyService);
+            () => this.InputedFromValue is not null && this.FromAccountSelectorVM?.SelectedKey != this.ToAccountSelectorVM?.SelectedKey, this.mBusyService);
         protected async Task OKCommand_ExecuteAsync()
         {
             // DB登録
@@ -287,8 +375,6 @@ namespace HouseholdAccountBook.ViewModels.Windows
             using FuncLog funcLog = new(new { initialAccountId, initialMonth, initialDate, targetGroupId });
             using IDisposable disposable = this.mBusyService.Enter();
 
-            AssetModel asset = AssetService.Instance.GetDefaultAssetModel();
-
             AccountIdObj selectingFromAccountId = null;
             AccountIdObj selectingToAccountId = null;
             ItemIdObj selectingCommissionItemId = null;
@@ -296,18 +382,17 @@ namespace HouseholdAccountBook.ViewModels.Windows
             string selectingCommissionRemark = null;
 
             switch (this.RegKind) {
-                case RegistrationKind.Add:
+                case RegistrationKind.Add: {
                     selectingFromAccountId = initialAccountId;
                     selectingToAccountId = initialAccountId;
                     selectingCommissionKind = CommissionKind.MoveFrom;
 
                     // WVMに値を設定する
-                    this.IsLink = true;
+                    this.IsDateLink = true;
                     this.SelectedFromDate = initialDate?.ToDateTime(TimeOnly.MinValue) ?? ((initialMonth == null || initialMonth?.Month == DateTime.Today.Month) ? DateTime.Today : initialMonth.Value.ToDateTime(TimeOnly.MinValue));
-                    this.ValueScale = asset.Scale;
-                    this.CommissionScale = asset.Scale;
 
                     break;
+                }
                 case RegistrationKind.Edit:
                 case RegistrationKind.Copy: {
                     // DBから値を読み込む
@@ -329,13 +414,15 @@ namespace HouseholdAccountBook.ViewModels.Windows
                     selectingCommissionItemId = commissionAction?.Item.Id;
                     selectingCommissionRemark = commissionAction?.Remark?.Remark;
 
-                    this.IsLink = fromAction.ActTime == toAction.ActTime;
+                    this.IsDateLink = fromAction.ActTime == toAction.ActTime;
+
                     this.SelectedFromDate = fromAction.ActTime;
+                    this.InputedFromValue = fromAction.Expenses?.MainValue; // 移動元帳簿の支出
+
                     this.SelectedToDate = toAction.ActTime;
-                    this.InputedValue = toAction.Amount.MainValue;
-                    this.ValueScale = toAction.Amount.Scale;
+                    this.InputedToValue = toAction.Income?.MainValue; // 移動先帳簿の収入
+
                     this.InputedCommission = commissionAction?.Expenses?.MainValue;
-                    this.CommissionScale = commissionAction?.Expenses?.Scale ?? (selectingCommissionKind == CommissionKind.MoveTo ? toAction.Amount.Scale : fromAction.Amount.Scale);
 
                     break;
                 }
@@ -361,22 +448,59 @@ namespace HouseholdAccountBook.ViewModels.Windows
                 }
                 break;
             }
+
+            // アセットIDを指定する
+            this.SelectedFromAccountAssetId = this.FromAccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+            this.SelectedToAccountAssetId = this.ToAccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+            this.SelectedCommissionAccountAssetId = this.CommissionKindSelectorVM.SelectedKey switch {
+                CommissionKind.MoveFrom => this.SelectedFromAccountAssetId,
+                CommissionKind.MoveTo => this.SelectedToAccountAssetId,
+                _ => throw new NotSupportedException("SelectedCommissionKind")
+            } ?? AssetIdObj.System;
         }
 
         public override void AddEventHandlers()
         {
             using FuncLog funcLog = new();
 
-            this.FromAccountSelectorVM.SelectionChanged += (sender, e) => this.FromAccountChanged?.Invoke(sender, e);
+            // 移動元帳簿変更時
+            this.FromAccountSelectorVM.SelectionChanged += (sender, e) => {
+                this.SelectedFromAccountAssetId = this.FromAccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+
+                if (this.CommissionKindSelectorVM.SelectedKey == CommissionKind.MoveFrom) {
+                    this.SelectedCommissionAccountAssetId = this.FromAccountSelectorVM.SelectedItem?.AssetId;
+                }
+
+                this.SelectedFromAccountChanged?.Invoke(sender, e);
+            };
             this.FromAccountSelectorVM.Children.Add(this.ItemSelectorVM);
 
-            this.ToAccountSelectorVM.SelectionChanged += (sender, e) => this.ToAccountChanged?.Invoke(sender, e);
+            // 移動先帳簿変更時
+            this.ToAccountSelectorVM.SelectionChanged += (sender, e) => {
+                this.SelectedToAccountAssetId = this.ToAccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+
+                if (this.CommissionKindSelectorVM.SelectedKey == CommissionKind.MoveTo) {
+                    this.SelectedCommissionAccountAssetId = this.ToAccountSelectorVM.SelectedItem?.AssetId;
+                }
+
+                this.SelectedToAccountChanged?.Invoke(sender, e);
+            };
             this.ToAccountSelectorVM.Children.Add(this.ItemSelectorVM);
 
-            this.CommissionKindSelectorVM.SelectionChanged += (sender, e) => this.CommissionKindChanged?.Invoke(sender, e);
+            // 手数料種別変更時
+            this.CommissionKindSelectorVM.SelectionChanged += (sender, e) => {
+                this.SelectedCommissionAccountAssetId = e.NewValue switch {
+                    CommissionKind.MoveFrom => this.SelectedFromAccountAssetId,
+                    CommissionKind.MoveTo => this.SelectedToAccountAssetId,
+                    _ => throw new NotSupportedException("SelectedCommissionKind")
+                } ?? AssetIdObj.System;
+
+                this.SelectedCommissionKindChanged?.Invoke(sender, e);
+            };
             this.CommissionKindSelectorVM.Children.Add(this.ItemSelectorVM);
 
-            this.ItemSelectorVM.SelectionChanged += (sender, e) => this.ItemChanged?.Invoke(sender, e);
+            // 項目変更時
+            this.ItemSelectorVM.SelectionChanged += (sender, e) => this.SelectedCommissionItemChanged?.Invoke(sender, e);
             this.ItemSelectorVM.Children.Add(this.RemarkSelectorVM);
         }
 
@@ -388,25 +512,37 @@ namespace HouseholdAccountBook.ViewModels.Windows
         {
             using FuncLog funcLog = new();
 
+            // 移動元
             ActionModel fromAction = new() {
-                Base = new(this.FromActionId, this.SelectedFromDate, new(-this.InputedValue.Value, this.ValueScale)),
+                Base = new(this.FromActionId, this.SelectedFromDate, new(-this.InputedFromValue.Value, this.SelectedFromAssetId)),
+                AssetId = AssetIdObj.System, // TODO: 将来の拡張用(証券口座間の株の移動など)
                 GroupId = this.GroupId,
                 Account = new(this.FromAccountSelectorVM.SelectedKey, string.Empty)
             };
 
+            // 移動先
             ActionModel toAction = new() {
-                Base = new(this.ToActionId, this.SelectedToDate, new(this.InputedValue.Value, this.ValueScale)),
+                Base = new(this.ToActionId, this.SelectedToDate, new(this.InputedToValue.Value, this.SelectedToAssetId)),
+                AssetId = AssetIdObj.System, // TODO: 将来の拡張用(証券口座間の株の移動など)
                 GroupId = this.GroupId,
                 Account = new(this.ToAccountSelectorVM.SelectedKey, string.Empty)
             };
 
+            // 手数料
             CommissionKind commissionKind = this.CommissionKindSelectorVM.SelectedKey;
+            DateTime commissionActTime = commissionKind switch {
+                CommissionKind.MoveFrom => fromAction.ActTime,
+                CommissionKind.MoveTo => toAction.ActTime,
+                _ => throw new NotSupportedException("SelectedCommissionKind")
+            };
+            SelectorViewModel<AccountModel, AccountIdObj> commissionSelectorVM = commissionKind switch {
+                CommissionKind.MoveFrom => this.FromAccountSelectorVM,
+                CommissionKind.MoveTo => this.ToAccountSelectorVM,
+                _ => throw new NotSupportedException("SelectedCommissionKind")
+            };
             ActionModel commissionAction = new() {
-                Base = new(this.CommissionId, commissionKind switch {
-                    CommissionKind.MoveFrom => fromAction.ActTime,
-                    CommissionKind.MoveTo => toAction.ActTime,
-                    _ => throw new NotSupportedException("SelectedCommissionKind")
-                }, new(-this.InputedCommission ?? 0m, this.CommissionScale)),
+                Base = new(this.CommissionId, commissionActTime, new(-this.InputedCommission ?? 0m, commissionSelectorVM.SelectedItem.AssetId)),
+                AssetId = AssetIdObj.System, // 今のところ固定を想定
                 GroupId = this.GroupId,
                 Account = new(commissionKind switch {
                     CommissionKind.MoveFrom => fromAction.Account.Id,

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowAccountTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowAccountTabViewModel.cs
@@ -141,7 +141,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 選択されたデータの平均値(平均値)
         /// </summary>
-        public string AverageValueStr => AssetService.Instance.ToAssetString(this.AverageValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string AverageValueStr => AssetService.Instance.ToAssetString(this.AverageValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
         /// <summary>
         /// 選択されたデータの個数
         /// </summary>
@@ -153,7 +153,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 選択されたデータの合計値(文字列)
         /// </summary>
-        public string SumValueStr => AssetService.Instance.ToAssetString(this.SumValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string SumValueStr => AssetService.Instance.ToAssetString(this.SumValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
         /// <summary>
         /// 選択されたデータの収入合計値
         /// </summary>
@@ -161,7 +161,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 選択されたデータの収入合計値(文字列)
         /// </summary>
-        public string IncomeSumValueStr => AssetService.Instance.ToAssetString(this.IncomeSumValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string IncomeSumValueStr => AssetService.Instance.ToAssetString(this.IncomeSumValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
         /// <summary>
         /// 選択されたデータの支出合計値
         /// </summary>
@@ -169,7 +169,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// <summary>
         /// 選択されたデータの支出合計値(文字列)
         /// </summary>
-        public string ExpensesSumValueStr => AssetService.Instance.ToAssetString(this.ExpensesSumValue, null, UnitKind.MainUnit, UnitKind.MainUnit);
+        public string ExpensesSumValueStr => AssetService.Instance.ToAssetString(this.ExpensesSumValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit);
 
         /// <summary>
         /// 概要セレクタVM
@@ -652,6 +652,14 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         public override void AddEventHandlers()
         {
             using FuncLog funcLog = new();
+
+            // アセット選択変更時
+            this.Parent.SelectedAssetChanged += (sender, e) => {
+                this.RaisePropertyChanged(nameof(this.AverageValueStr));
+                this.RaisePropertyChanged(nameof(this.SumValueStr));
+                this.RaisePropertyChanged(nameof(this.IncomeSumValueStr));
+                this.RaisePropertyChanged(nameof(this.ExpensesSumValueStr));
+            };
 
             // 帳簿項目選択変更時
             this.ActionSelectorVM.SelectedCollectionChanged += (sender, e) => {

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowGraphTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowGraphTabViewModel.cs
@@ -213,7 +213,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             }
 
             // 縦軸 - 線形軸
-            AssetModel assetModel = AssetService.Instance.GetDefaultAssetModel();
+            AssetModel assetModel = AssetService.Instance.GetAssetModel(this.Parent.AccountSelectorVM.SelectedItem.AssetId);
             string unitY = assetModel?.Name ?? Resources.Unit_DefaultMoney;
             LinearAxis GetVerticalAxis()
             {
@@ -291,7 +291,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                             ItemsSource = tmpVM.Values.Zip(tmpVM.Periods.Select(period => period.Start), (value, date) => new GraphDatumViewModel {
                                 Value = value.MainValue,
                                 Date = date,
-                                DisplayValue = AssetService.Instance.ToAssetString(value.MainValue, null, UnitKind.MainUnit, UnitKind.MainUnit),
+                                DisplayValue = AssetService.Instance.ToAssetString(value.MainValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit),
                                 Item = tmpVM.Item,
                                 Category = tmpVM.Category
                             }),
@@ -338,7 +338,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                         ItemsSource = tmpVM.Values.Select((value, index) => (value, index)).Zip(tmpVM.Periods.Select(period => period.Start), (tmp, date) => new GraphDatumViewModel() {
                             Value = tmp.value.MainValue,
                             Date = date,
-                            DisplayValue = AssetService.Instance.ToAssetString(tmp.value.MainValue, null, UnitKind.MainUnit, UnitKind.MainUnit),
+                            DisplayValue = AssetService.Instance.ToAssetString(tmp.value.MainValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit),
                             Index = tmp.index
                         }),
                         TrackerFormatString = this.GetTrackerFormatString(false),
@@ -386,7 +386,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                     ItemsSource = vm.Values.Zip(vm.Periods.Select(period => period.Start), (value, date) => new GraphDatumViewModel {
                         Value = value.MainValue,
                         Date = date,
-                        DisplayValue = AssetService.Instance.ToAssetString(value.MainValue, null, UnitKind.MainUnit, UnitKind.MainUnit),
+                        DisplayValue = AssetService.Instance.ToAssetString(value.MainValue, this.Parent.SelectedAssetId, UnitKind.MainUnit, UnitKind.MainUnit),
                         Item = vm.Item,
                         Category = vm.Category
                     }),

--- a/HouseholdAccountBook/ViewModels/WindowsParts/SettingsWindowAccountTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/SettingsWindowAccountTabViewModel.cs
@@ -144,7 +144,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
                 AccountKind = vm.AccountKindSelectorVM.SelectedKey,
                 AssetId = vm.AssetSelectorVM.SelectedKey,
                 Remark = vm.InputedRemark ?? string.Empty,
-                InitialValue = new(vm.InputedInitialValue, vm.InitialValueScale),
+                InitialValue = new(vm.InputedInitialValue, vm.AssetSelectorVM.SelectedKey),
                 StartDateExists = vm.SelectedIfStartDateExists,
                 EndDateExists = vm.SelectedIfEndDateExists,
                 Period = vm.InputedPeriod,

--- a/HouseholdAccountBook/Views/Windows/ActionListRegistrationWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/ActionListRegistrationWindow.xaml
@@ -134,12 +134,12 @@
                     <controls:DataGridEditableTemplateColumn Header="{x:Static properties:Resources.ColumnHeader_Date}" Width="*">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Margin="4,3,4,5" Text="{Binding ActDate, StringFormat=\{0:yyyy-MM-dd\}}"/>
+                                <TextBlock Margin="4,3,4,5" Text="{Binding SelectedDate, StringFormat=\{0:yyyy-MM-dd\}}"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
-                                <controls:DateTimePicker DateFormat="yyyy-MM-dd" SelectedDate="{Binding ActDate, Mode=TwoWay}"/>
+                                <controls:DateTimePicker DateFormat="yyyy-MM-dd" SelectedDate="{Binding SelectedDate, Mode=TwoWay}"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellEditingTemplate>
                     </controls:DataGridEditableTemplateColumn>
@@ -153,12 +153,12 @@
                         </DataGridTemplateColumn.CellStyle>
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <TextBlock Margin="3,1" Text="{Binding ActValueStr}" TextAlignment="Right"/>
+                                <TextBlock Margin="3,1" Text="{Binding InputedValueStr}" TextAlignment="Right"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
-                                <controls:NumericUpDown Session="{Binding Session}" Value="{Binding ActValue, UpdateSourceTrigger=PropertyChanged}" Scale="{Binding Scale}" 
+                                <controls:NumericUpDown Session="{Binding Session}" Value="{Binding InputedValue, UpdateSourceTrigger=PropertyChanged}" Scale="{Binding ValueScale}" 
                                                         GotFocus="NumericUpDown_GotFocus" IsMouseWheelEnabled="False" IsPopupEnabled="False"/>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellEditingTemplate>

--- a/HouseholdAccountBook/Views/Windows/ActionListRegistrationWindow.xaml.cs
+++ b/HouseholdAccountBook/Views/Windows/ActionListRegistrationWindow.xaml.cs
@@ -37,9 +37,9 @@ namespace HouseholdAccountBook.Views.Windows
         /// <summary>
         /// 帳簿変更時のイベント
         /// </summary>
-        public event EventHandler<ChangedEventArgs<AccountIdObj>> AccountChanged {
-            add => this.WVM.AccountChanged += value;
-            remove => this.WVM.AccountChanged -= value;
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedAccountChanged {
+            add => this.WVM.SelectedAccountChanged += value;
+            remove => this.WVM.SelectedAccountChanged -= value;
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace HouseholdAccountBook.Views.Windows
             // 入力時処理
             numericUpDown.ButtonInputed(this.WVM.InputedValue, this.WVM.InputedKind);
             // Bindしているが、何故かコピーしないと反映されない
-            this.mLastDateValueVM.ActValue = numericUpDown.Value;
+            this.mLastDateValueVM.InputedValue = numericUpDown.Value;
             // FollowablePopup の 表示状態をコピー
             this.WVM.IsOpenPopup = numericUpDown.IsOpen;
 
@@ -159,17 +159,17 @@ namespace HouseholdAccountBook.Views.Windows
             if (this.WVM.InputedDateValueVMList.Count == 0) {
                 // ダミーデータ
                 e.NewItem = new DateValueViewModel() {
-                    ActDate = DateTime.Now,
-                    ActValue = null
+                    SelectedDate = DateTime.Now,
+                    InputedValue = null
                 };
             }
             else {
                 // リストに入力済の末尾のデータの日付を追加時に採用する
                 DateValueViewModel lastVM = this.WVM.InputedDateValueVMList.Last();
                 e.NewItem = new DateValueViewModel() {
-                    ActDate = this.WVM.IsDateAutoIncrement ? lastVM.ActDate.AddDays(1) : lastVM.ActDate,
-                    ActValue = null,
-                    Scale = lastVM.Scale
+                    SelectedDate = this.WVM.IsDateAutoIncrement ? lastVM.SelectedDate.AddDays(1) : lastVM.SelectedDate,
+                    InputedValue = null,
+                    SelectedAccountAssetId = this.WVM.AccountSelectorVM.SelectedItem.AssetId
                 };
             }
         }

--- a/HouseholdAccountBook/Views/Windows/ActionRegistrationWindow.xaml.cs
+++ b/HouseholdAccountBook/Views/Windows/ActionRegistrationWindow.xaml.cs
@@ -19,26 +19,26 @@ namespace HouseholdAccountBook.Views.Windows
     {
         #region イベント
         /// <summary>
+        /// 帳簿変更時のイベント
+        /// </summary>
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedAccountChanged {
+            add => this.WVM.SelectedAccountChanged += value;
+            remove => this.WVM.SelectedAccountChanged -= value;
+        }
+        /// <summary>
+        /// 日時変更時のイベント
+        /// </summary>
+        public event EventHandler<ChangedEventArgs<DateTime>> SelectedDateChanged {
+            add => this.WVM.SelectedDateChanged += value;
+            remove => this.WVM.SelectedDateChanged -= value;
+        }
+
+        /// <summary>
         /// 登録時のイベント
         /// </summary>
         public event EventHandler<EventArgs<IEnumerable<ActionIdObj>>> Registrated {
             add => this.WVM.Registrated += value;
             remove => this.WVM.Registrated -= value;
-        }
-
-        /// <summary>
-        /// 帳簿変更時のイベント
-        /// </summary>
-        public event EventHandler<ChangedEventArgs<AccountIdObj>> AccountChanged {
-            add => this.WVM.AccountChanged += value;
-            remove => this.WVM.AccountChanged -= value;
-        }
-        /// <summary>
-        /// 日時変更時のイベント
-        /// </summary>
-        public event EventHandler<ChangedEventArgs<DateTime>> DateChanged {
-            add => this.WVM.DateChanged += value;
-            remove => this.WVM.DateChanged -= value;
         }
         #endregion
 

--- a/HouseholdAccountBook/Views/Windows/MoveRegistrationWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/MoveRegistrationWindow.xaml
@@ -47,7 +47,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
@@ -73,6 +72,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -101,6 +101,13 @@
                                              DateFormat="yyyy-MM-dd" SelectedDate="{Binding SelectedFromDate}"/>
                     <Button Grid.Row="2" Grid.Column="3" Margin="5"
                             Content="{x:Static properties:Resources.Button_Today}" Command="{Binding TodayCommand}"/>
+
+                    <!-- 金額 -->
+                    <TextBlock Grid.Row="3" Grid.Column="0" Margin="5" 
+                           Text="{x:Static properties:Resources.TextBlock_AmountOfMoney}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                    <controls:NumericUpDown Grid.Row="3" Grid.Column="1" Margin="5"
+                                        Value="{Binding InputedFromValue}" MinValue="0" Scale="{Binding FromValueScale}"/>
+                    <TextBlock Grid.Row="3" Grid.Column="2" Margin="5" HorizontalAlignment="Right" Text="{Binding InputedFromValueStr}"/>
                 </Grid>
             </GroupBox>
 
@@ -109,6 +116,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         
+                        <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
@@ -134,33 +142,21 @@
                     <TextBlock Grid.Row="2" Grid.Column="0" Margin="5" 
                                Text="{x:Static properties:Resources.TextBlock_Date}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
                     <controls:DateTimePicker x:Name="movingDateTimePicker" Grid.Row="2" Grid.Column="1" Margin="5"
-                                             DateFormat="yyyy-MM-dd" SelectedDate="{Binding SelectedToDate}" IsEnabled="{Binding IsLink, Converter={StaticResource NegationConverter}, Mode=TwoWay}"/>
+                                             DateFormat="yyyy-MM-dd" SelectedDate="{Binding SelectedToDate}" IsEnabled="{Binding IsDateLink, Converter={StaticResource NegationConverter}}"/>
                     <CheckBox Grid.Row="2" Grid.Column="3" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Center" 
                               Content="{x:Static properties:Resources.CheckBox_Setting}" IsChecked="{Binding IsEnabled, ElementName=movingDateTimePicker}"/>
 
+                    <!-- 金額 -->
+                    <TextBlock Grid.Row="3" Grid.Column="0" Margin="5" 
+                               Text="{x:Static properties:Resources.TextBlock_AmountOfMoney}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                    <controls:NumericUpDown Grid.Row="3" Grid.Column="1" Margin="5"
+                                            Value="{Binding InputedToValue}" MinValue="0" Scale="{Binding ToValueScale}" IsEnabled="{Binding IsSameAsset, Converter={StaticResource NegationConverter}}"/>
+                    <TextBlock Grid.Row="3" Grid.Column="2" Margin="5" HorizontalAlignment="Right" Text="{Binding InputedToValueStr}"/>
                 </Grid>
             </GroupBox>
 
-            <Grid Grid.Row="3">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="0.25*"/>
-                    <ColumnDefinition Width="0.5*"/>
-                    <ColumnDefinition Width="0.25*"/>
-                </Grid.ColumnDefinitions>
-
-                <!-- 金額 -->
-                <TextBlock Grid.Row="7" Grid.Column="0" Margin="5" 
-                           Text="{x:Static properties:Resources.TextBlock_AmountOfMoney}" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                <controls:NumericUpDown Grid.Row="7" Grid.Column="1" Margin="5"
-                                        Value="{Binding InputedValue, TargetNullValue=''}" MinValue="0" Scale="{Binding ValueScale}"/>
-                <TextBlock Grid.Row="7" Grid.Column="2" Margin="5" HorizontalAlignment="Right" Text="{Binding InputedValueStr}"/>
-            </Grid>
-
             <!-- 手数料 -->
-            <GroupBox Grid.Row="4" Header="{x:Static properties:Resources.TextBlock_Comission}">
+            <GroupBox Grid.Row="3" Header="{x:Static properties:Resources.TextBlock_Comission}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/HouseholdAccountBook/Views/Windows/MoveRegistrationWindow.xaml.cs
+++ b/HouseholdAccountBook/Views/Windows/MoveRegistrationWindow.xaml.cs
@@ -18,7 +18,22 @@ namespace HouseholdAccountBook.Views.Windows
     {
         #region イベント
         /// <summary>
-        /// 登録時イベント
+        /// 移動元帳簿変更時のイベント
+        /// </summary>
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedFromAccountChanged {
+            add => this.WVM.SelectedFromAccountChanged += value;
+            remove => this.WVM.SelectedFromAccountChanged -= value;
+        }
+        /// <summary>
+        /// 移動先帳簿変更時のイベント
+        /// </summary>
+        public event EventHandler<ChangedEventArgs<AccountIdObj>> SelectedToAccountChanged {
+            add => this.WVM.SelectedToAccountChanged += value;
+            remove => this.WVM.SelectedToAccountChanged -= value;
+        }
+
+        /// <summary>
+        /// 登録時のイベント
         /// </summary>
         public event EventHandler<EventArgs<IEnumerable<ActionIdObj>>> Registrated {
             add => this.WVM.Registrated += value;

--- a/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml
+++ b/HouseholdAccountBook/Views/Windows/SettingsWindow.xaml
@@ -196,9 +196,9 @@
                                         </GroupBox>
 
                                         <!-- ベースレート -->
-                                        <TextBlock Grid.Row="6" Grid.Column="0" Margin="5" Visibility="Collapsed"
+                                        <TextBlock Grid.Row="6" Grid.Column="0" Margin="5"
                                                    Text="{x:Static properties:Resources.TextBlock_AssetBaseRate}"/>
-                                        <controls:NumericUpDown Grid.Row="6" Grid.Column="1" Margin="5" Visibility="Collapsed"
+                                        <controls:NumericUpDown Grid.Row="6" Grid.Column="1" Margin="5"
                                                                 Value="{Binding InputedBaseRate}" MinValue="0" IsFloating="True"/>
 
                                         <!-- スケール -->
@@ -360,9 +360,9 @@
                                                  Text="{Binding InputedRemark, UpdateSourceTrigger=PropertyChanged}"/>
 
                                         <!-- アセット -->
-                                        <TextBlock Grid.Row="5" Grid.Column="0" Margin="5" Visibility="Collapsed"
+                                        <TextBlock Grid.Row="5" Grid.Column="0" Margin="5"
                                                    Text="{x:Static properties:Resources.TextBlock_Asset}"/>
-                                        <ComboBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" Visibility="Collapsed"
+                                        <ComboBox Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" Margin="5"
                                                   ItemsSource="{Binding AssetSelectorVM.ItemList}" SelectedItem="{Binding AssetSelectorVM.SelectedItem}" DisplayMemberPath="Name"/>
 
                                         <!-- 初期残高 -->


### PR DESCRIPTION
## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- 異なる通貨やポイントなどを同時に扱いたい

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- 帳簿ごとにアセットを設定可能に変更
- 帳簿ごとに設定されたアセットに応じた金額が表示されるように変更
- 移動の登録で、移動元と移動先の帳簿のアセットが異なる場合に、移動元と移動先それぞれの金額を入力可能に変更

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. ドルを扱う帳簿を作成する
   1. スケール2、単位$、ベースレート150

1. 対象の帳簿を選択して、以下の表示を確認する
   1. 帳簿項目タブの帳簿項目の一覧、概要、ステータスバーの金額表記
   1. 一覧タブの表記
   1. グラフタブの表記
1. 帳簿として一覧を選択して、同様の表示を確認する
   1. デフォルトアセットで表示されている

1. 対象の帳簿に対して、帳簿項目の追加、編集を確認する
   1. 円の帳簿が選択された時は、スケール0、単位￥で表示される
   1. ドルの帳簿が選択された時は、スケール2、単位$で表示される
1. 円とドルを扱う帳簿間で、移動の追加、編集を確認する

1. CSV比較で、ドルを扱う帳簿で、CSVファイルを開いて、以下の表示を確認する
   1. 読み込んだデータ、ステータスバーの金額表記

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #214

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
