### PR TITLE
#227 起動時の選択帳簿がデフォルトアセットではない場合にステータスバーの金額表記の単位が異なる

### DIFF
--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -6,6 +6,9 @@
 
 ### 2026-07-20
 
+- MainWindow
+   - ↑起動したときの帳簿のアセットでデフォルトと異なるときにステータスバーの金額の単位が異なるのを修正した - refs #227
+
 - MoveRegistrationWindow
    - △移動関係の英語表現を修正した(MoveFrom->Source, MoveTo->Destination, Commission->Fee, Burden->ChargedTo) - refs #222
 

--- a/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/Windows/MainWindowViewModel.cs
@@ -1174,6 +1174,7 @@ namespace HouseholdAccountBook.ViewModels.Windows
 
             // アセットを更新する
             this.SelectedAssetId = this.AccountSelectorVM.SelectedItem?.AssetId ?? AssetIdObj.System;
+            this.AccountTabVM.RaiseSelectedAssetChanged();
 
             await this.UpdateAsync(isUpdateAccountList: false, isScroll: true, isUpdateActDateLastEdited: true);
         }

--- a/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowAccountTabViewModel.cs
+++ b/HouseholdAccountBook/ViewModels/WindowsParts/MainWindowAccountTabViewModel.cs
@@ -519,6 +519,16 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
         /// 最後のバックアップ日時が変更されたことを通知する
         /// </summary>
         public void RaiseCurrentBackUpChanged() => this.RaisePropertyChanged(nameof(this.CurrentBackUp));
+        /// <summary>
+        /// 選択されたアセットが変更されたことを通知する
+        /// </summary>
+        public void RaiseSelectedAssetChanged()
+        {
+            this.RaisePropertyChanged(nameof(this.AverageValueStr));
+            this.RaisePropertyChanged(nameof(this.SumValueStr));
+            this.RaisePropertyChanged(nameof(this.IncomeSumValueStr));
+            this.RaisePropertyChanged(nameof(this.ExpensesSumValueStr));
+        }
 
         /// <summary>
         /// <see cref="FilteredActionVMList"/> を更新する
@@ -654,12 +664,7 @@ namespace HouseholdAccountBook.ViewModels.WindowsParts
             using FuncLog funcLog = new();
 
             // アセット選択変更時
-            this.Parent.SelectedAssetChanged += (sender, e) => {
-                this.RaisePropertyChanged(nameof(this.AverageValueStr));
-                this.RaisePropertyChanged(nameof(this.SumValueStr));
-                this.RaisePropertyChanged(nameof(this.IncomeSumValueStr));
-                this.RaisePropertyChanged(nameof(this.ExpensesSumValueStr));
-            };
+            this.Parent.SelectedAssetChanged += (sender, e) => this.RaiseSelectedAssetChanged();
 
             // 帳簿項目選択変更時
             this.ActionSelectorVM.SelectedCollectionChanged += (sender, e) => {


### PR DESCRIPTION


## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- アプリ終了時に選択された帳簿が、アプリ起動時に初期選択される
- アプリ起動時にデフォルトアセットと異なる帳簿が選択された場合に、ステータスバーの金額の単位が異なる

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- 起動したときの帳簿のアセットでデフォルトと異なるときにステータスバーの金額の単位が異なるのを修正

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. デフォルトアセットと異なる帳簿を選択した状態でアプリを終了する
1. アプリを起動して、ステータスバーの金額の単位が合っているか確認する

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #227

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
