### PR TITLE
#231 AssetService::ToAssetString の FuncLog の出力を削除する

### DIFF
--- a/HouseholdAccountBook/Models/AppServices/AssetService.cs
+++ b/HouseholdAccountBook/Models/AppServices/AssetService.cs
@@ -70,8 +70,6 @@ namespace HouseholdAccountBook.Models.AppServices
         /// <returns>金額の文字列表現</returns>
         public string ToAssetString(decimal? value, AssetIdObj assetId, UnitKind inputKind, UnitKind outputKind, UnitPosition position = UnitPosition.Both)
         {
-            using FuncLog funcLog = new(new { value, assetId, inputKind, outputKind, position }, Log.LogLevel.Trace);
-
             AssetModel asset = this.GetAssetModel(assetId);
             if (asset is null) { return value.ToString(); }
 
@@ -119,7 +117,6 @@ namespace HouseholdAccountBook.Models.AppServices
                     break;
             }
 
-            funcLog.Returns = new { ret };
             return ret;
         }
 

--- a/HouseholdAccountBook/Resources/UpdateLog.md
+++ b/HouseholdAccountBook/Resources/UpdateLog.md
@@ -6,6 +6,9 @@
 
 ### 2026-07-20
 
+- 全体
+   - ×AssetService::ToAssetString の FuncLog の出力を削除した - refs #231
+
 - MainWindow
    - ↑起動したときの帳簿のアセットでデフォルトと異なるときにステータスバーの金額の単位が異なるのを修正した - refs #227
 


### PR DESCRIPTION


## Summary / 概要
Please describe the purpose and background of this PR.  
このPRの目的・背景を記載してください。

- AssetService::ToAssetString は、金額に単位などを付与する際に呼ばれるため、呼び出し頻度が高い
- 結果として、ログが大量に出てしまうので、FuncLog によるログ出力を削除したい(Debugビルド時のみ対象)

---

## Changes / 変更内容
List the main changes included in this PR.  
このPRに含まれる主な変更点を箇条書きで記載してください。

- AssetService::ToAssetString の FuncLog の出力を削除

---

## How to Test / 動作確認
Describe the steps to verify the changes.  
変更内容を確認するための手順を記載してください。

1. 出力ログレベル Trace でログを確認する

---

## Related Issues / 関連Issue
Link related issues using `close #123` or similar.  
関連するIssueを `close #123` などの形式で記載してください。

- close #231
- refs #210

---

## Notes / 備考
Add any additional notes or considerations.  
補足事項や注意点があれば記載してください。

- None / なし

<!-- Copilot Instruction:
If you review this pull request,
- Write all review comments in Japanese
- Do not switch to English
-->
